### PR TITLE
Adding support for PDEs with terms like u(2x) and not just u(x)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.1.2"
 [deps]
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.2"
 [deps]
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"

--- a/src/symbolic_discretize.jl
+++ b/src/symbolic_discretize.jl
@@ -2,8 +2,8 @@ function cardinalize_eqs!(pdesys)
     for (i, eq) in enumerate(pdesys.eqs)
         pdesys.eqs[i] = eq.lhs - eq.rhs ~ 0
     end
-    for (i, eq) in enumerate(pdesys.bcs)
-        pdesys.eqs[i] = eq.lhs - eq.rhs ~ 0
+    for (i, bc) in enumerate(pdesys.bcs)
+        pdesys.bcs[i] = bc.lhs - bc.rhs ~ 0
     end
 end
 

--- a/src/symbolic_discretize.jl
+++ b/src/symbolic_discretize.jl
@@ -2,6 +2,9 @@ function cardinalize_eqs!(pdesys)
     for (i, eq) in enumerate(pdesys.eqs)
         pdesys.eqs[i] = eq.lhs - eq.rhs ~ 0
     end
+    for (i, eq) in enumerate(pdesys.bcs)
+        pdesys.eqs[i] = eq.lhs - eq.rhs ~ 0
+    end
 end
 
 function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::AbstractDiscretization)

--- a/src/variable_map.jl
+++ b/src/variable_map.jl
@@ -1,13 +1,43 @@
 struct VariableMap
+    """
+    Calls of the dependent variable, not including boundary terms
+    """
     ū
+    """
+    Independent variables, excluding time
+    """
     x̄
+    """
+    Parameters
+    """
     ps
+    """
+    Time independent variable (nothing, if not applicable)
+    """
     time
+    """
+    Dictionary mapping independent variables to their domain
+    """
     intervals
+    """
+    Dictionary mapping dependent variables to their arguments (which are independent variables)
+    """
     args
+    """
+    ??? Dependent variables ???
+    """
     depvar_ops
+    """
+    Dictionary mapping independent variables to indices
+    """
     x2i
+    """
+    Dictionary mapping indices to independent variables
+    """
     i2x
+    """
+    ???
+    """
     replaced_vars
 end
 
@@ -73,4 +103,19 @@ x2i(v::VariableMap, u, x) = findfirst(isequal(x), remove(v.args[operation(u)], v
     map(ivs(u, v)) do x
         x => (I[x2i(v, u, x)] == 1 ? v.intervals[x][1] : v.intervals[x][2])
     end
+end
+
+import Base.==
+
+function ==(a::VariableMap, b::VariableMap)
+    all(simplify.(a.ū .== b.ū)) &&
+        all(simplify.(a.x̄ .== b.x̄)) &&
+        all(simplify.(a.ps .== b.ps)) &&
+        a.time == b.time &&
+        a.intervals == b.intervals &&
+        all([all(simplify.(a.args[k] .== b.args[k])) for k in keys(a.args) ∪ keys(b.args)]) &&
+        a.depvar_ops == b.depvar_ops &&
+        a.x2i == b.x2i &&
+        all([simplify(a.i2x[k] == b.i2x[k]) for k in keys(a.i2x) ∪ keys(b.i2x)]) &&
+        a.replaced_vars == b.replaced_vars
 end

--- a/src/variable_map.jl
+++ b/src/variable_map.jl
@@ -73,7 +73,7 @@ function VariableMap(pdesys, disc; replaced_vars = Dict())
                     filter(_u -> isequal(operation(_u), u), alldepvars)
                 ) 
             for u in depvar_ops
-        ] # [operation(u) => arguments(u) for u in ū]
+        ]
     x̄2dim = [x̄[i] => i for i in 1:nspace]
     dim2x̄ = [i => x̄[i] for i in 1:nspace]
     return VariableMap(ū, x̄, ps, time, Dict(intervals), Dict(args), depvar_ops, Dict(x̄2dim), Dict(dim2x̄), replaced_vars)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,10 @@ const is_TRAVIS = haskey(ENV, "TRAVIS")
 
 const is_CI = haskey(ENV, "CI")
 
-# Currently verified by Downstream tests
-@test true
+@time begin
+#    # Currently verified by Downstream tests
+#    @test true
+    if GROUP == "All" || GROUP == "VariableMap"
+        @time @safetestset "VariableMap" begin include("variable_map_tests.jl") end
+    end
+end

--- a/test/variable_map_tests.jl
+++ b/test/variable_map_tests.jl
@@ -57,8 +57,8 @@ time = nothing
 intervals = Dict([x => (x0, x_end), y => (y0, y_end)])
 depvar_ops = [operation(safe_unwrap(u(x,y)))]
 args = Dict(depvar_ops[1] => [x, y])
-x2i = Dict([x => 1, y => 2])
-i2x = Dict([1 => x, 2 => y])
+x2i = Dict([x => 2, y => 1])
+i2x = Dict([2 => x, 1 => y])
 replaced_vars = Dict()
 
 v_generated = VariableMap(pde_system) 
@@ -73,7 +73,7 @@ println("Approximation of function 1D 2")
 
 func(x) = @. abs(x - 0.5) - 0.5
 
-eq = [u(2x) - u(0) ~ func(2x)]
+eq = [u(2x - u(x-3)) - u(0) ~ func(2x)]
 bc = [u(0) ~ 2.5]
 
 x0 = 0
@@ -82,7 +82,7 @@ domain = [x ∈ (x0, x_end)]
 
 @named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
 
-ū = [u(2x)]
+ū = [u(2x - u(x-3)), u(x-3)]
 x̄ = [x]
 ps = []
 time = nothing

--- a/test/variable_map_tests.jl
+++ b/test/variable_map_tests.jl
@@ -1,0 +1,66 @@
+using ModelingToolkit, PDEBase
+
+## Approximation of function 1D
+println("Approximation of function 1D")
+
+@parameters x
+@variables u(..)
+
+func(x) = @. 2 + abs(x - 0.5)
+
+eq = [u(x) ~ func(x)]
+bc = [u(0) ~ u(0)]
+
+x0 = 0
+x_end = 2
+domain = [x ∈ (x0, x_end)]
+
+@named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
+
+ū = [u(x)]
+x̄ = [x]
+ps = []
+time = nothing
+intervals = Dict(x => (x0, x_end))
+depvar_ops = [operation(safe_unwrap(u(x)))]
+args = Dict(depvar_ops[1] => [x])
+x2i = Dict(x => 1)
+i2x = Dict(1 => x)
+replaced_vars = Dict()
+
+v_generated = VariableMap(pde_system) 
+v_true = VariableMap(ū, x̄, ps, time, intervals, args, depvar_ops, x2i, i2x, replaced_vars)
+@test v_generated == v_true
+
+## Approximation of function 2D
+println("Approximation of function 2D")
+
+@parameters x, y
+@variables u(..)
+func(x, y) = -cos(x) * cos(y) * exp(-((x - pi)^2 + (y - pi)^2))
+eq = [u(x, y) ~ func(x, y)]
+bc = [u(0, 0) ~ u(0, 0)]
+
+x0 = -10
+x_end = 10
+y0 = -10
+y_end = 10
+d = 0.4
+
+domain = [x ∈ (x0, x_end), y ∈ (y0, y_end)]
+@named pde_system = PDESystem(eq, bc, domain, [x, y], [u(x, y)])
+
+ū = [u(x, y)]
+x̄ = [x, y]
+ps = []
+time = nothing
+intervals = Dict([x => (x0, x_end), y => (y0, y_end)])
+depvar_ops = [operation(safe_unwrap(u(x,y)))]
+args = Dict(depvar_ops[1] => [x, y])
+x2i = Dict([x => 1, y => 2])
+i2x = Dict([1 => x, 2 => y])
+replaced_vars = Dict()
+
+v_generated = VariableMap(pde_system) 
+v_true = VariableMap(ū, x̄, ps, time, intervals, args, depvar_ops, x2i, i2x, replaced_vars)
+@test v_generated == v_true

--- a/test/variable_map_tests.jl
+++ b/test/variable_map_tests.jl
@@ -64,3 +64,35 @@ replaced_vars = Dict()
 v_generated = VariableMap(pde_system) 
 v_true = VariableMap(ū, x̄, ps, time, intervals, args, depvar_ops, x2i, i2x, replaced_vars)
 @test v_generated == v_true
+
+## Approximation of function 1D 2
+println("Approximation of function 1D 2")
+
+@parameters x
+@variables u(..)
+
+func(x) = @. abs(x - 0.5) - 0.5
+
+eq = [u(2x) - u(0) ~ func(2x)]
+bc = [u(0) ~ 2.5]
+
+x0 = 0
+x_end = 2
+domain = [x ∈ (x0, x_end)]
+
+@named pde_system = PDESystem(eq, bc, domain, [x], [u(x)])
+
+ū = [u(2x)]
+x̄ = [x]
+ps = []
+time = nothing
+intervals = Dict(x => (x0, x_end))
+depvar_ops = [operation(safe_unwrap(u(x)))]
+args = Dict(depvar_ops[1] => [x])
+x2i = Dict(x => 1)
+i2x = Dict(1 => x)
+replaced_vars = Dict()
+
+v_generated = VariableMap(pde_system) 
+v_true = VariableMap(ū, x̄, ps, time, intervals, args, depvar_ops, x2i, i2x, replaced_vars)
+@test v_generated == v_true


### PR DESCRIPTION
This PR adds a get_all_indvars function so that constructing a VariableMap from a PDESystem does not assume that the arguments of the function calls are always independent variables.

PINNs aren't limited to simple PDEs like $\partial_{xx} u = \partial_t u$, but can even be used to solve strange equations such as $u\left(2x - u(x - 3)\right) = x^2$. To properly parse such expressions in Julia's PINN package, NeuralPDE, we cannot in this package assume that the argument of $u(\cdot)$ is always a list of independent variables.

This PR also adds test cases for this functionality, which rely on a (likely flawed) equality operation for VariableMap objects.

@xtalax These are the changes to PDEBase I've made, re: our discussion on Slack of changing the NeuralPDE parser.