### PR TITLE
Fix spelling errors

### DIFF
--- a/src/interface_defaults.jl
+++ b/src/interface_defaults.jl
@@ -75,7 +75,7 @@ This is a type useful for doing any precalculations that are needed for the disc
 construct_differential_discretizer(pdesys, s, discretization, orders) = nothing
 
 """
-    discretize_equation!(disc_state::AbstractDiscretizationState, pde::Equaation, vareqmap::AbstractVarEqMap,
+    discretize_equation!(disc_state::AbstractDiscretizationState, pde::Equation, vareqmap::AbstractVarEqMap,
                          eqvar, bcmap, depvars, s::AbstractDiscreteSpace,
                          derivweights::AbstractDifferentialDiscretizer, indexmap, discretization::AbstractDiscretization)
 Add the information from the given pde equation to the discretization state. Also, discretize the bcs associated with the eqvar.

--- a/src/parse_boundaries.jl
+++ b/src/parse_boundaries.jl
@@ -43,7 +43,7 @@ struct UpperBoundary <: AbstractTruncatingBoundary
     end
 end
 
-# Note that it is assumed throughout MOL that the variables in an inteface BC have the same argument signature,
+# Note that it is assumed throughout MOL that the variables in an interface BC have the same argument signature,
 # differing in only one variable which is that of the interface. This is not checked here, but will cause errors if it is not true.
 # Interfaces are assumed to be on the lower boundary of the domain.
 

--- a/src/symbolic_discretize.jl
+++ b/src/symbolic_discretize.jl
@@ -53,7 +53,7 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Abstra
     # Generate finite difference weights
     derivweights = construct_differential_discretizer(pdesys, s, discretization, orders)
 
-    # Seperate bcs and ics
+    # Separate bcs and ics
     ics = t === nothing ? [] : mapreduce(u -> boundarymap[u][t], vcat, operation.(depvars(v)))
 
     bcmap = Dict(map(collect(keys(boundarymap))) do u


### PR DESCRIPTION
## Summary

Fix 3 spelling errors found by typos spell checker.

## Changes Made

- **inteface → interface**: Fixed comment in parse_boundaries.jl
- **Equaation → Equation**: Fixed function signature in interface_defaults.jl
- **Seperate → Separate**: Fixed comment in symbolic_discretize.jl

## Files Changed

- src/parse_boundaries.jl (1 fix)
- src/interface_defaults.jl (1 fix)
- src/symbolic_discretize.jl (1 fix)

**Total: 3 spelling fixes across 3 files**

## Notes

- All changes are simple typo corrections that don't affect functionality
- Changes include comments and documentation strings only