### PR TITLE
Fix #67: Add offset methods for boundaries and include dispatch tests

### DIFF
--- a/src/parse_boundaries.jl
+++ b/src/parse_boundaries.jl
@@ -228,6 +228,10 @@ function isupper(::InterfaceBoundary{IsUpper_u}) where {IsUpper_u}
 end
 isupper(::HigherOrderInterfaceBoundary) = true
 
+offset(::LowerBoundary, i, len) = i
+offset(::UpperBoundary, i, len) = len - i + 1
+offset(b::AbstractInterfaceBoundary, i, len) = isupper(b) ? len - i + 1 : i
+
 flatten_vardict(bmps) = reduce(vcat, reduce(vcat, collect.(values.(collect(values(bmps))))))
 
 function _boundary_rules(v, orders, u, x, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,22 @@ const is_CI = haskey(ENV, "CI")
     end
 end
 
+# Verify correct dispatch and calculations for boundary offsets (Resolves #67)
+@safetestset "Boundary Type Hierarchy and Offset Dispatch Tests" begin
+    using Test
+    using PDEBase
+
+    upper_interface = PDEBase.InterfaceBoundary{Val(true), Val(false)}(1, 2, 3, 4, 5)
+    lower_interface = PDEBase.InterfaceBoundary{Val(false), Val(true)}(1, 2, 3, 4, 5)
+
+    @test PDEBase.offset(upper_interface, 2, 10) == 9
+    @test PDEBase.offset(lower_interface, 2, 10) == 2
+
+    @test hasmethod(PDEBase.offset, Tuple{PDEBase.LowerBoundary, Int, Int})
+    @test hasmethod(PDEBase.offset, Tuple{PDEBase.UpperBoundary, Int, Int})
+    @test hasmethod(PDEBase.offset, Tuple{PDEBase.HigherOrderInterfaceBoundary, Int, Int})
+end
+
 # Run allocation tests in a separate group to avoid precompilation interference
 if GROUP == "All" || GROUP == "nopre"
     @safetestset "Allocation Tests" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Resolves #67.

Implemented "Option A" as suggested by @xtalax to provide fallback `offset` implementations for boundary types.

**Key details:**
* Added `offset` methods directly to `LowerBoundary` and `UpperBoundary` (instead of `AbstractLowerBoundary` / `AbstractUpperBoundary` as originally suggested, since those abstract types are not defined in the current hierarchy and caused an `UndefVarError` during local testing).
* Added a new `@safetestset` to verify correct dispatch and offset calculations, preventing future regressions.
