### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.22"
+version = "0.1.23"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]
@@ -19,7 +19,7 @@ DomainSets = "0.7"
 JET = "0.9, 0.10, 0.11"
 ModelingToolkit = "11"
 PrecompileTools = "1"
-SciMLBase = "2"
+SciMLBase = "2, 3.1"
 SymbolicIndexingInterface = "0.3.40"
 SymbolicUtils = "4"
 Symbolics = "7"


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

Extend `SciMLBase` compat to include v3.1 (keep the existing lower bound and v2 support). No code changes required — a grep of `src/` and `test/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, single-int non-scalar timeseries `sol[i]` indexing, or removed getproperty aliases like `.destats` / `.minimizer`).

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54` while SciMLBase 3.1 requires RAT v4. Expect CI on this PR to fail at the `Pkg.add` step with an unsatisfiable resolution error until upstream OrdinaryDiffEq releases a RAT-v4-compatible version; re-running afterward should go green without further edits.

## Context

Part of the SciMLBase v3 ecosystem sweep — see SciML/DiffEqCallbacks.jl#300 and SciML/DiffEqParamEstim.jl#290 for the reference patterns for code-side changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)