### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,11 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -7,15 +7,10 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.julia-version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
-        os: [ubuntu-latest]
         package:
           - {user: SciML, repo: MethodOfLines.jl, group: Components}
           - {user: SciML, repo: MethodOfLines.jl, group: Sol_Interface}
@@ -33,38 +28,10 @@ jobs:
           - {user: SciML, repo: PDESystemLibrary.jl, group: MOL}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: ${{ matrix.julia-version }}
-          arch: x64
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: "1"
+      owner: "${{ matrix.package.user }}"
+      repo: "${{ matrix.package.repo }}"
+      group: "${{ matrix.package.group }}"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/src/discretization_state.jl
+++ b/src/discretization_state.jl
@@ -10,7 +10,7 @@ end
 function generate_system(
         disc_state::EquationState, s, u0, tspan, metadata,
         disc::AbstractEquationSystemDiscretization;
-        checks=true
+        checks = true
     )
     discvars = get_discvars(s)
     t = get_time(disc)
@@ -69,9 +69,9 @@ end
 function SciMLBase.discretize(
         pdesys::PDESystem,
         discretization::AbstractEquationSystemDiscretization;
-        analytic = nothing, checks=true, kwargs...
+        analytic = nothing, checks = true, kwargs...
     )
-    sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization; checks=checks)
+    sys, tspan = SciMLBase.symbolic_discretize(pdesys, discretization; checks = checks)
     return try
         simpsys = mtkcompile(sys)
         if tspan === nothing
@@ -94,7 +94,7 @@ function SciMLBase.discretize(
             ps_raw = get_ps(mol_metadata.pdesys)
             if ps_raw !== nothing && ps_raw !== SciMLBase.NullParameters() && !isempty(ps_raw)
                 # get_ps may return Pairs (e.g. [v => 0.5]); extract parameter values
-                param_vals = Dict{Any,Any}()
+                param_vals = Dict{Any, Any}()
                 if first(ps_raw) isa Pair
                     for p in ps_raw
                         param_vals[first(p)] = last(p)

--- a/src/interface_defaults.jl
+++ b/src/interface_defaults.jl
@@ -143,7 +143,7 @@ function generate_system(
         disc_state::AbstractDiscretizationState, s::AbstractDiscreteSpace,
         u0, tspan, metadata::AbstractDiscretizationMetadata,
         discretization::AbstractDiscretization;
-        checks=true
+        checks = true
     )
     return nothing
 end

--- a/src/make_pdesys_compatible.jl
+++ b/src/make_pdesys_compatible.jl
@@ -215,7 +215,7 @@ function handle_complex(pdesys)
                 half = n_eqs ÷ 2
                 eqs = vcat(
                     [_replace_ops(eq.lhs, redvmaps_dict) ~ _replace_ops(eq.rhs, redvmaps_dict) for eq in eqs_flat[1:half]],
-                    [_replace_ops(eq.lhs, imdvmaps_dict) ~ _replace_ops(eq.rhs, imdvmaps_dict) for eq in eqs_flat[half+1:end]]
+                    [_replace_ops(eq.lhs, imdvmaps_dict) ~ _replace_ops(eq.rhs, imdvmaps_dict) for eq in eqs_flat[(half + 1):end]]
                 )
             else
                 # Odd number of equations - just rename all with real maps

--- a/src/symbolic_discretize.jl
+++ b/src/symbolic_discretize.jl
@@ -6,7 +6,7 @@ function cardinalize_eqs!(pdesys)
     return
 end
 
-function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::AbstractDiscretization; checks=true)
+function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::AbstractDiscretization; checks = true)
     t = get_time(discretization)
     pdesys, complexmap = handle_complex(pdesys)
     cardinalize_eqs!(pdesys)
@@ -96,5 +96,5 @@ function SciMLBase.symbolic_discretize(pdesys::PDESystem, discretization::Abstra
     # Pass u0 to generate_metadata for storage (needed for MTK v11 compatibility)
     metadata = generate_metadata(s, discretization, pdesys, boundarymap, complexmap, u0)
 
-    return generate_system(disc_state, s, u0, tspan, metadata, discretization; checks=checks)
+    return generate_system(disc_state, s, u0, tspan, metadata, discretization; checks = checks)
 end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

## Summary

Converts all of PDEBase.jl CI to the centralized SciML/.github reusable workflows pinned at `@v1`, with `secrets: "inherit"` on every caller.

### Converted (inline -> central caller)
- **Runic** (`FormatCheck.yml`): `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck** (`SpellCheck.yml`): `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade** (`Downgrade.yml`): inline -> `downgrade.yml@v1` (`julia-version: "1.10"`, `skip: "Pkg,TOML"`, preserving the existing `if: false`)
- **Downstream/IntegrationTest** (`Downstream.yml`): inline -> matrix of `downstream.yml@v1` callers, preserving the full MethodOfLines/PDESystemLibrary/NeuralPDE package+group list

### Already central (left as-is, already have `secrets: "inherit"`)
- **Tests** (`Tests.yml`): `tests.yml@v1`, version×group matrix (1/lts/pre × Core/QA, with the `pre`/QA exclude) preserved
- **Documentation** (`Documentation.yml`): `documentation.yml@v1`

### Other
- **Runic formatting**: applied Runic v1 in-place to `src/*.jl` (spacing around `=` in keyword args, `Dict{Any, Any}`, range parenthesization). No behavior change.
- **typos**: 0 fixes needed (already clean); no `_typos.toml` added.
- **dependabot.yml**: removed the `crate-ci/typos` ignore entry; dropped `/test` from the julia ecosystem `directories` (it has no `Project.toml`); kept `/` and `/docs`. `github-actions` (weekly, `/`) and `julia` (daily, group `all-julia-packages: ["*"]`) blocks retained.
- `TagBot.yml` unchanged. No `CompatHelper.yml` present.

### Note
Check names will change (now `Runic`, `Spell Check with Typos`, `Downgrade`, downstream matrix entries via reusable workflows). **Branch-protection required-status-check names will need updating** accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)