### PR TITLE
Allow DomainSets 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.24"
+version = "0.1.25"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]
@@ -15,7 +15,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 AllocCheck = "0.2"
 BenchmarkTools = "1"
-DomainSets = "0.7"
+DomainSets = "0.7, 0.8"
 ModelingToolkit = "11"
 PrecompileTools = "1"
 SciMLBase = "2, 3.1"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## What

Widen the `DomainSets` compat bound from `0.7` to `0.7, 0.8` and bump the version to `0.1.25`.

## Why

This unblocks the DomainSets `0.7 -> 0.8` dependabot bump in MethodOfLines.jl ([SciML/MethodOfLines.jl#564](https://github.com/SciML/MethodOfLines.jl/pull/564)). That PR currently fails to resolve because PDEBase (a MethodOfLines dependency) still pins `DomainSets = "0.7"`:

```
ERROR: LoadError: Unsatisfiable requirements detected for package PDEBase [a7812802]:
 └─restricted by compatibility requirements with DomainSets [5b8099bc] to versions: uninstalled — no versions left
caused by: empty intersection between DomainSets@0.7.18 and project compatibility 0.8
```

## DomainSets 0.8 breaking changes and why they don't affect PDEBase

DomainSets v0.8.0 ([JuliaApproximation/DomainSets.jl#178](https://github.com/JuliaApproximation/DomainSets.jl/issues/178)):
1. Removed an old type piracy so `DomainSets.×` and `LinearAlgebra.×` are now distinct functions.
2. Unexported some internal symbols that now live in FunctionMaps.jl.

PDEBase's only DomainSets usage is in `src/variable_map.jl`:

```julia
x => (DomainSets.infimum(xdomain.domain), DomainSets.supremum(xdomain.domain))
```

Both `infimum` and `supremum` are fully qualified and remain exported in DomainSets 0.8 (verified locally), and PDEBase uses no bare `×` and no unexported internals. So **no source changes are required** — only the compat bound.

## Local verification

DomainSets 0.8.0 was confirmed to provide every name PDEBase/MethodOfLines rely on:

```
DomainSets version: 0.8.0
infimum          defined=true exported=true
supremum         defined=true exported=true
Interval         defined=true exported=true
ClosedInterval   defined=true exported=true
```

A MethodOfLines test environment with this PDEBase branch + the matching ModelingToolkitBase compat bump developed in resolves DomainSets to **0.8.0** and runs the MethodOfLines Components and Diffusion test groups (see the MethodOfLines PR for full output). PDEBase precompiles cleanly against DomainSets 0.8.0.

> Note: PDEBase's own `Pkg.test` (which pulls ModelingToolkit) cannot resolve DomainSets 0.8 until ModelingToolkitBase also admits it — see the companion ModelingToolkit PR. PDEBase itself is source-compatible; this is purely a transitive resolver constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Part of the DomainSets 0.8 set: SciML/MethodOfLines.jl#565 (consumer), SciML/ModelingToolkit.jl#4586 (ModelingToolkitBase, the other 0.7 pin).