### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,25 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - Core
-          - QA
-        exclude:
-          # JET 0.11.x has `julia = "1.12"` registry compat (1.12.x only),
-          # so it cannot resolve on Julia 1.13 prereleases. Skip the QA
-          # group on `pre` until upstream JET widens its julia compat.
-          - version: "pre"
-            group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,8 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+# JET 0.11.x has `julia = "1.12"` registry compat (1.12.x only), so it cannot
+# resolve on Julia 1.13 prereleases. Keep QA off `pre` until upstream JET
+# widens its julia compat.
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root `Tests.yml` test workflow to the canonical thin caller using `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the group × version matrix declared once in a new root `test/test_groups.toml`.

### Changes
- **`.github/workflows/Tests.yml`** — the matrix test job is replaced by the thin caller:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
  `name: "Tests"`, the `on:` triggers, and `concurrency:` are preserved verbatim so branch-protection status checks are unaffected. No other workflow files were touched (Downgrade, Downstream, Documentation, FormatCheck, SpellCheck, TagBot, RunicSuggestions, DependabotAutoMerge, DocPreviewCleanup all left as-is).
- **`test/test_groups.toml`** (new):
  ```toml
  [Core]
  versions = ["lts", "1", "pre"]

  [QA]
  versions = ["lts", "1"]
  ```

### Why no `with:` inputs
`runtests.jl` already dispatches on the standard `GROUP` env var (Core/QA), so the default `group-env-name` (`GROUP`) applies. The old caller invoked `tests.yml@v1` with all defaults (`check-bounds=yes`, `coverage=true`, `coverage-directories=src,ext`, `apt-packages=""`), all of which match `grouped-tests.yml`'s defaults — so the thin caller needs no `with:` block.

### Matrix match: 5/5 exact
Old workflow matrix was `version: [1, lts, pre] × group: [Core, QA]` with `exclude: pre × QA` → 5 cells. Running `compute_affected_sublibraries.jl <root> --root-matrix` against the new `test/test_groups.toml` emits exactly:
- (Core, lts), (Core, 1), (Core, pre)
- (QA, lts), (QA, 1)

The QA-off-`pre` constraint (JET 0.11.x cannot resolve on Julia 1.13 prereleases) is preserved by declaring QA's `versions = ["lts", "1"]` rather than via a matrix `exclude`.

### Verification
- Root-matrix script run with Julia 1.11: reproduces old matrix 5/5 exact.
- `test/test_groups.toml` parses (Julia `TOML`); `Tests.yml` parses (YAML).

### QA findings
None. This is a CI-plumbing change only; `runtests.jl` already had Core/QA GROUP dispatch (QA = JET static analysis), so no source or test changes were made.

Ignore until reviewed by @ChrisRackauckas.