### PR TITLE
Restore contents:write permission for docs deploy (fix gh-pages 403)

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,5 +14,9 @@ concurrency:
 jobs:
   build-and-deploy-docs:
     name: "Documentation"
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     uses: "SciML/.github/.github/workflows/documentation.yml@v1"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The docs **build** passes, but the `deploydocs` push to `gh-pages` fails (403 / push denied to `github-actions[bot]`). The Documentation workflow uses the centralized reusable `SciML/.github/.github/workflows/documentation.yml@v1` with `secrets: "inherit"` and no `DOCUMENTER_KEY` secret, so Documenter falls back to a token-based `gh-pages` push using `GITHUB_TOKEN`.

## Root cause

The CI-centralization migration replaced the docs job with a thin caller of `documentation.yml@v1` but **dropped the `permissions:` block** from the caller job. The reusable workflow declares no `permissions`, so the caller job's permissions (now the default, read-only `contents`) flow through to the `GITHUB_TOKEN` used inside the called workflow. A read-only token cannot push to `gh-pages` -> 403.

## Fix

Declare `permissions: { actions: write, contents: write, statuses: write }` on the reusable-workflow **caller** job in `Documentation.yml`. For a `uses:` reusable-workflow job, the caller job's `permissions` are passed through to the `GITHUB_TOKEN` used inside the called workflow, restoring the token-based deploy mechanism. No secret is required.

This mirrors the proven fix in SciML/OrdinaryDiffEqOperatorSplitting.jl#90 exactly.

## Verification

- YAML validated locally (`python3 yaml.safe_load`) — OK.
- The deploy itself cannot be fully verified without a CI run on `master`/a tag (gh-pages push only happens on the default branch / tags, not on PR builds). The fix is correct by matching the proven #90 pattern and the pre-migration permission set.

Please ignore until reviewed by @ChrisRackauckas