### PR TITLE
Bump version to 0.1.27

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.1.26 -> 0.1.27) to release unreleased commits on `master` via JuliaRegistrator.