### PR TITLE
Release prep: bump PDEBase to 0.1.28

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.27"
+version = "0.1.28"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release to register the accumulated docstring/QA/test-scaffolding changes since 0.1.27.