### PR TITLE
feat: wire discrete MOL ICs into MTK initialization system

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -25,7 +25,7 @@ jobs:
           - {user: SciML, repo: MethodOfLines.jl, group: Integrals}
           - {user: SciML, repo: MethodOfLines.jl, group: Burgers}
           - {user: SciML, repo: MethodOfLines.jl, group: DAE}
-          - {user: SciML, repo: PDESystemLibrary.jl, group: MOL}
+          - {user: SciML, repo: PDESystemLibrary.jl, group: Core}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]

--- a/src/PDEBase.jl
+++ b/src/PDEBase.jl
@@ -7,7 +7,7 @@ using ModelingToolkit
 using ModelingToolkit: get_unknowns, ProblemTypeCtx, get_ps, get_bcs, get_dvs,
     get_eqs, get_iv,
     get_domain, get_ivs, get_systems, get_connector_type,
-    get_metadata, get_gui_metadata, Differential
+    get_metadata, get_gui_metadata
 
 using Symbolics, SymbolicUtils
 using Symbolics: unwrap, setname, rename

--- a/src/PDEBase.jl
+++ b/src/PDEBase.jl
@@ -7,7 +7,8 @@ using ModelingToolkit
 using ModelingToolkit: get_unknowns, ProblemTypeCtx, get_ps, get_bcs, get_dvs,
     get_eqs, get_iv,
     get_domain, get_ivs, get_systems, get_connector_type,
-    get_metadata, get_gui_metadata
+    get_metadata, get_gui_metadata,
+    split_indexed_var, get_stable_index, Differential
 
 using Symbolics, SymbolicUtils
 using Symbolics: unwrap, setname, rename

--- a/src/PDEBase.jl
+++ b/src/PDEBase.jl
@@ -7,8 +7,7 @@ using ModelingToolkit
 using ModelingToolkit: get_unknowns, ProblemTypeCtx, get_ps, get_bcs, get_dvs,
     get_eqs, get_iv,
     get_domain, get_ivs, get_systems, get_connector_type,
-    get_metadata, get_gui_metadata,
-    split_indexed_var, get_stable_index, Differential
+    get_metadata, get_gui_metadata, Differential
 
 using Symbolics, SymbolicUtils
 using Symbolics: unwrap, setname, rename

--- a/src/discretization_state.jl
+++ b/src/discretization_state.jl
@@ -7,6 +7,24 @@ function EquationState()
     return EquationState(Equation[], Equation[])
 end
 
+function _split_discrete_ic_key(x)
+    x = unwrap(x)
+    iscall(x) || return x, (), false
+
+    op = operation(x)
+    args = arguments(x)
+    if op === getindex
+        idx = Tuple(unwrap_const(safe_unwrap(i)) for i in args[2:end])
+        return first(args), idx, true
+    elseif op isa Differential && length(args) == 1
+        arr, idx, isarr = _split_discrete_ic_key(first(args))
+        return isarr ? (op(arr), idx, true) : (x, (), false)
+    end
+    return x, (), false
+end
+
+_discrete_ic_value(v) = unwrap_const(safe_unwrap(v))
+
 """
     discrete_u0_to_atomic_map(u0)
 
@@ -20,35 +38,25 @@ function discrete_u0_to_atomic_map(u0)
     scalars = Dict{Any, Any}()
     for (k, v) in u0
         k = unwrap(k)
-        arr, isarr = split_indexed_var(k)
+        arr, idx, isarr = _split_discrete_ic_key(k)
         if isarr
             buf = get!(() -> Dict{Any, Any}(), groups, arr)
-            buf[get_stable_index(k)] = v
+            buf[idx] = v
         else
-            scalars[k] = v
+            scalars[k] = _discrete_ic_value(v)
         end
     end
     out = Dict{Any, Any}()
     for (arr, idxs) in groups
-        vals = Array{Float64}(undef, size(arr))
+        vals = Array{Any}(undef, size(arr))
         fill!(vals, NaN)
         for (idx, v) in idxs
-            vals[idx] = Float64(try
-                Symbolics.value(v)
-            catch
-                v
-            end)
+            vals[idx...] = _discrete_ic_value(v)
         end
         out[arr] = vals
     end
     return merge!(out, scalars)
 end
-
-_numeric_ic_value(v) = Float64(try
-    Symbolics.value(v)
-catch
-    v
-end)
 
 """
     variables_with_time_derivative(eqs, t)
@@ -99,12 +107,11 @@ function discrete_initialization(eqs, t, u0)
     for dv in variables_with_time_derivative(eqs, t)
         dv_u = unwrap(dv)
         if haskey(u0_dict, dv_u)
-            push!(init_eqs, dv ~ _numeric_ic_value(u0_dict[dv_u]))
+            push!(init_eqs, dv ~ _discrete_ic_value(u0_dict[dv_u]))
         else
-            # try isequal match (identity of keys can differ by wrapping)
             for (k, v) in u0_dict
                 if isequal(k, dv_u)
-                    push!(init_eqs, dv ~ _numeric_ic_value(v))
+                    push!(init_eqs, dv ~ _discrete_ic_value(v))
                     break
                 end
             end

--- a/src/discretization_state.jl
+++ b/src/discretization_state.jl
@@ -7,6 +7,113 @@ function EquationState()
     return EquationState(Equation[], Equation[])
 end
 
+"""
+    discrete_u0_to_atomic_map(u0)
+
+Convert indexed discrete IC pairs `(u(t))[i] => val` into a map compatible with
+ModelingToolkit v11 `AtomicArrayDict` (whole-array keys only, e.g. `u(t) => values`).
+Used for `guesses` / non-indexed maps. Empty input returns an empty `Dict`.
+"""
+function discrete_u0_to_atomic_map(u0)
+    isempty(u0) && return Dict{Any, Any}()
+    groups = Dict{Any, Dict{Any, Any}}()
+    scalars = Dict{Any, Any}()
+    for (k, v) in u0
+        k = unwrap(k)
+        arr, isarr = split_indexed_var(k)
+        if isarr
+            buf = get!(() -> Dict{Any, Any}(), groups, arr)
+            buf[get_stable_index(k)] = v
+        else
+            scalars[k] = v
+        end
+    end
+    out = Dict{Any, Any}()
+    for (arr, idxs) in groups
+        vals = Array{Float64}(undef, size(arr))
+        fill!(vals, NaN)
+        for (idx, v) in idxs
+            vals[idx] = Float64(try
+                Symbolics.value(v)
+            catch
+                v
+            end)
+        end
+        out[arr] = vals
+    end
+    return merge!(out, scalars)
+end
+
+_numeric_ic_value(v) = Float64(try
+    Symbolics.value(v)
+catch
+    v
+end)
+
+"""
+    variables_with_time_derivative(eqs, t)
+
+Return discrete unknowns that appear under `Differential(t)` in `eqs`. These are
+the differential states whose initial values should be hard initialization
+equations; remaining (algebraic) discrete states should only be guesses.
+"""
+function variables_with_time_derivative(eqs, t)
+    found = Any[]
+    t = unwrap(t)
+    function walk(ex)
+        ex = unwrap(ex)
+        if iscall(ex)
+            op = operation(ex)
+            args = arguments(ex)
+            if op isa Differential && isequal(op.x, t)
+                push!(found, args[1])
+            end
+            foreach(walk, args)
+        end
+        return nothing
+    end
+    for eq in eqs
+        walk(eq.lhs)
+        walk(eq.rhs)
+    end
+    return unique(found)
+end
+
+"""
+    discrete_initialization(eqs, t, u0)
+
+Build MTK initialization data from discrete IC pairs:
+
+- **Hard** `initialization_eqs`: `var ~ val` only for variables that appear under
+  `Differential(t)` (differential states). This matches the continuous IC
+  structure and avoids over-determining algebraic residuals.
+- **Guesses**: all discrete ICs as whole-array maps (algebraic nodes use the
+  projected continuous IC as a starting guess for the init solve).
+
+Returns `(initialization_eqs, guesses)`.
+"""
+function discrete_initialization(eqs, t, u0)
+    isempty(u0) && return Equation[], Dict{Any, Any}()
+    u0_dict = Dict{Any, Any}(unwrap(k) => v for (k, v) in u0)
+    init_eqs = Equation[]
+    for dv in variables_with_time_derivative(eqs, t)
+        dv_u = unwrap(dv)
+        if haskey(u0_dict, dv_u)
+            push!(init_eqs, dv ~ _numeric_ic_value(u0_dict[dv_u]))
+        else
+            # try isequal match (identity of keys can differ by wrapping)
+            for (k, v) in u0_dict
+                if isequal(k, dv_u)
+                    push!(init_eqs, dv ~ _numeric_ic_value(v))
+                    break
+                end
+            end
+        end
+    end
+    guesses = discrete_u0_to_atomic_map(u0)
+    return init_eqs, guesses
+end
+
 function generate_system(
         disc_state::EquationState, s, u0, tspan, metadata,
         disc::AbstractEquationSystemDiscretization;
@@ -19,17 +126,22 @@ function generate_system(
     alleqs = vcat(disc_state.eqs, unique(disc_state.bceqs))
     alldepvarsdisc = vec(reduce(vcat, vec(unique(reduce(vcat, vec.(values(discvars)))))))
 
-    # u0 is now stored in metadata (passed during metadata construction)
-    # MTK v11's AtomicArrayDict doesn't allow indexed array symbolics as keys in initial_conditions
-    # Only pass non-indexed initial conditions to System
-    sys_defaults = Dict(pdesys.initial_conditions)
+    # Continuous/non-indexed defaults from the PDESystem (parameters, etc.)
+    sys_defaults = Dict{Any, Any}(pdesys.initial_conditions)
+    # Discrete grid ICs: hard init eqs for differential states + guesses for all
+    # (including algebraic). Do not dump indexed keys into AtomicArrayDict ICs.
+    init_eqs = Equation[]
+    guesses = Dict{Any, Any}()
+    if t !== nothing && !isempty(u0)
+        init_eqs, guesses = discrete_initialization(alleqs, t, u0)
+    end
 
     ps_raw = get_ps(pdesys)
     ps_raw = ps_raw === nothing || ps_raw === SciMLBase.NullParameters() ? Num[] : ps_raw
     # get_ps may return Pairs (e.g. [v => 0.5]); extract symbols and merge values into defaults
     if !isempty(ps_raw) && first(ps_raw) isa Pair
         ps = Num[first(p) for p in ps_raw]
-        merge!(sys_defaults, Dict(first(p) => last(p) for p in ps_raw))
+        merge!(sys_defaults, Dict{Any, Any}(first(p) => last(p) for p in ps_raw))
     else
         ps = ps_raw
     end
@@ -48,7 +160,11 @@ function generate_system(
             # * In the end we have reduced the problem to a system of equations in terms of Dt that can be solved by an ODE solver.
 
             sys = System(
-                alleqs, t, alldepvarsdisc, ps; initial_conditions = sys_defaults, name = name,
+                alleqs, t, alldepvarsdisc, ps;
+                initial_conditions = sys_defaults,
+                initialization_eqs = init_eqs,
+                guesses = guesses,
+                name = name,
                 metadata = [ProblemTypeCtx => metadata], checks = checks
             )
             return sys, tspan
@@ -86,15 +202,15 @@ function SciMLBase.discretize(
         else
             mol_metadata = getmetadata(simpsys, ProblemTypeCtx, nothing)
             add_metadata!(mol_metadata, sys)
-            # Get u0 from metadata (stored there for MTK v11 compatibility)
-            u0 = hasproperty(mol_metadata, :u0) ? mol_metadata.u0 : []
-            # Get parameter values from the original pdesys initial_conditions
-            # MTK v11 needs parameter values passed explicitly when creating ODEProblem
+            # Discrete ICs are already on the System as initialization_eqs (differential
+            # states) and guesses (all grid values). Do not re-pass indexed u0 pairs as
+            # the ODEProblem operating point: that forces every grid value as a hard IC
+            # and over-determines algebraic residuals. Only pass parameters here.
             pdesys_ic = mol_metadata.pdesys.initial_conditions
             ps_raw = get_ps(mol_metadata.pdesys)
+            param_vals = Dict{Any, Any}()
             if ps_raw !== nothing && ps_raw !== SciMLBase.NullParameters() && !isempty(ps_raw)
                 # get_ps may return Pairs (e.g. [v => 0.5]); extract parameter values
-                param_vals = Dict{Any, Any}()
                 if first(ps_raw) isa Pair
                     for p in ps_raw
                         param_vals[first(p)] = last(p)
@@ -114,28 +230,15 @@ function SciMLBase.discretize(
                         end
                     end
                 end
-                if !isempty(param_vals)
-                    # MTK v11 API: merge u0 and params into a single Dict
-                    op = merge(Dict(u0), param_vals)
-                    prob = ODEProblem(
-                        simpsys, op, tspan; build_initializeprob = false,
-                        discretization.kwargs...,
-                        kwargs...
-                    )
-                else
-                    prob = ODEProblem(
-                        simpsys, u0, tspan; build_initializeprob = false,
-                        discretization.kwargs...,
-                        kwargs...
-                    )
-                end
-            else
-                prob = ODEProblem(
-                    simpsys, u0, tspan; build_initializeprob = false,
-                    discretization.kwargs...,
-                    kwargs...
-                )
             end
+            # Enable MTK initialization (DefaultInit -> OverrideInit).
+            # Callers may override build_initializeprob / op via kwargs.
+            op = isempty(param_vals) ? nothing : param_vals
+            prob = ODEProblem(
+                simpsys, op, tspan; build_initializeprob = true,
+                discretization.kwargs...,
+                kwargs...
+            )
             if analytic === nothing
                 return prob
             else

--- a/src/discretization_state.jl
+++ b/src/discretization_state.jl
@@ -16,7 +16,7 @@ function _split_discrete_ic_key(x)
     if op === getindex
         idx = Tuple(unwrap_const(safe_unwrap(i)) for i in args[2:end])
         return first(args), idx, true
-    elseif op isa Differential && length(args) == 1
+    elseif op isa Symbolics.Differential && length(args) == 1
         arr, idx, isarr = _split_discrete_ic_key(first(args))
         return isarr ? (op(arr), idx, true) : (x, (), false)
     end
@@ -25,99 +25,44 @@ end
 
 _discrete_ic_value(v) = unwrap_const(safe_unwrap(v))
 
-"""
-    discrete_u0_to_atomic_map(u0)
-
-Convert indexed discrete IC pairs `(u(t))[i] => val` into a map compatible with
-ModelingToolkit v11 `AtomicArrayDict` (whole-array keys only, e.g. `u(t) => values`).
-Used for `guesses` / non-indexed maps. Empty input returns an empty `Dict`.
-"""
-function discrete_u0_to_atomic_map(u0)
-    isempty(u0) && return Dict{Any, Any}()
-    groups = Dict{Any, Dict{Any, Any}}()
-    scalars = Dict{Any, Any}()
-    for (k, v) in u0
-        k = unwrap(k)
-        arr, idx, isarr = _split_discrete_ic_key(k)
-        if isarr
-            buf = get!(() -> Dict{Any, Any}(), groups, arr)
-            buf[idx] = v
-        else
-            scalars[k] = _discrete_ic_value(v)
-        end
+function _time_derivative_order(x, t)
+    x = unwrap(x)
+    iscall(x) || return x, 0
+    op = operation(x)
+    if op isa Symbolics.Differential && isequal(op.x, t)
+        return first(arguments(x)), op.order
     end
-    out = Dict{Any, Any}()
-    for (arr, idxs) in groups
-        vals = Array{Any}(undef, size(arr))
-        fill!(vals, NaN)
-        for (idx, v) in idxs
-            vals[idx...] = _discrete_ic_value(v)
-        end
-        out[arr] = vals
-    end
-    return merge!(out, scalars)
+    return x, 0
 end
 
-"""
-    variables_with_time_derivative(eqs, t)
-
-Return discrete unknowns that appear under `Differential(t)` in `eqs`. These are
-the differential states whose initial values should be hard initialization
-equations; remaining (algebraic) discrete states should only be guesses.
-"""
-function variables_with_time_derivative(eqs, t)
-    found = Any[]
-    t = unwrap(t)
-    function walk(ex)
-        ex = unwrap(ex)
-        if iscall(ex)
-            op = operation(ex)
-            args = arguments(ex)
-            if op isa Differential && isequal(op.x, t)
-                push!(found, args[1])
-            end
-            foreach(walk, args)
-        end
-        return nothing
-    end
-    for eq in eqs
-        walk(eq.lhs)
-        walk(eq.rhs)
-    end
-    return unique(found)
-end
-
-"""
-    discrete_initialization(eqs, t, u0)
-
-Build MTK initialization data from discrete IC pairs:
-
-- **Hard** `initialization_eqs`: `var ~ val` only for variables that appear under
-  `Differential(t)` (differential states). This matches the continuous IC
-  structure and avoids over-determining algebraic residuals.
-- **Guesses**: all discrete ICs as whole-array maps (algebraic nodes use the
-  projected continuous IC as a starting guess for the init solve).
-
-Returns `(initialization_eqs, guesses)`.
-"""
-function discrete_initialization(eqs, t, u0)
+function _discrete_initialization(eqs, t, u0)
     isempty(u0) && return Equation[], Dict{Any, Any}()
-    u0_dict = Dict{Any, Any}(unwrap(k) => v for (k, v) in u0)
+    t = unwrap(t)
+    differential_orders = Dict{Any, Real}()
+    for eq in eqs, derivative in Symbolics.get_differential_vars(eq)
+        var, order = _time_derivative_order(derivative, t)
+        order > 0 || continue
+        differential_orders[var] = max(order, get(differential_orders, var, 0))
+    end
+
     init_eqs = Equation[]
-    for dv in variables_with_time_derivative(eqs, t)
-        dv_u = unwrap(dv)
-        if haskey(u0_dict, dv_u)
-            push!(init_eqs, dv ~ _discrete_ic_value(u0_dict[dv_u]))
+    guesses = Dict{Any, Any}()
+    for (key, value) in u0
+        key = unwrap(key)
+        value = _discrete_ic_value(value)
+        var, order = _time_derivative_order(key, t)
+        if order < get(differential_orders, var, 0)
+            push!(init_eqs, key ~ value)
+        end
+
+        array, index, isindexed = _split_discrete_ic_key(key)
+        if isindexed
+            values = get!(() -> fill!(Array{Any}(undef, size(array)), NaN), guesses, array)
+            values[index...] = value
         else
-            for (k, v) in u0_dict
-                if isequal(k, dv_u)
-                    push!(init_eqs, dv ~ _discrete_ic_value(v))
-                    break
-                end
-            end
+            guesses[key] = value
         end
     end
-    guesses = discrete_u0_to_atomic_map(u0)
     return init_eqs, guesses
 end
 
@@ -133,14 +78,11 @@ function generate_system(
     alleqs = vcat(disc_state.eqs, unique(disc_state.bceqs))
     alldepvarsdisc = vec(reduce(vcat, vec(unique(reduce(vcat, vec.(values(discvars)))))))
 
-    # Continuous/non-indexed defaults from the PDESystem (parameters, etc.)
     sys_defaults = Dict{Any, Any}(pdesys.initial_conditions)
-    # Discrete grid ICs: hard init eqs for differential states + guesses for all
-    # (including algebraic). Do not dump indexed keys into AtomicArrayDict ICs.
     init_eqs = Equation[]
     guesses = Dict{Any, Any}()
     if t !== nothing && !isempty(u0)
-        init_eqs, guesses = discrete_initialization(alleqs, t, u0)
+        init_eqs, guesses = _discrete_initialization(alleqs, t, u0)
     end
 
     ps_raw = get_ps(pdesys)
@@ -209,40 +151,8 @@ function SciMLBase.discretize(
         else
             mol_metadata = getmetadata(simpsys, ProblemTypeCtx, nothing)
             add_metadata!(mol_metadata, sys)
-            # Discrete ICs are already on the System as initialization_eqs (differential
-            # states) and guesses (all grid values). Do not re-pass indexed u0 pairs as
-            # the ODEProblem operating point: that forces every grid value as a hard IC
-            # and over-determines algebraic residuals. Only pass parameters here.
-            pdesys_ic = mol_metadata.pdesys.initial_conditions
-            ps_raw = get_ps(mol_metadata.pdesys)
-            param_vals = Dict{Any, Any}()
-            if ps_raw !== nothing && ps_raw !== SciMLBase.NullParameters() && !isempty(ps_raw)
-                # get_ps may return Pairs (e.g. [v => 0.5]); extract parameter values
-                if first(ps_raw) isa Pair
-                    for p in ps_raw
-                        param_vals[first(p)] = last(p)
-                    end
-                else
-                    # Fall back to looking up parameters in initial_conditions
-                    ps_unwrapped = [safe_unwrap(p) for p in ps_raw]
-                    for (k, v) in pairs(pdesys_ic)
-                        k_unwrapped = safe_unwrap(k)
-                        if any(p -> isequal(k_unwrapped, safe_unwrap(p)), ps_unwrapped)
-                            v_numeric = try
-                                Symbolics.value(v)
-                            catch
-                                safe_unwrap(v)
-                            end
-                            param_vals[k] = v_numeric
-                        end
-                    end
-                end
-            end
-            # Enable MTK initialization (DefaultInit -> OverrideInit).
-            # Callers may override build_initializeprob / op via kwargs.
-            op = isempty(param_vals) ? nothing : param_vals
             prob = ODEProblem(
-                simpsys, op, tspan; build_initializeprob = true,
+                simpsys, nothing, tspan;
                 discretization.kwargs...,
                 kwargs...
             )

--- a/test/discrete_initialization.jl
+++ b/test/discrete_initialization.jl
@@ -1,0 +1,52 @@
+using PDEBase
+using ModelingToolkit
+using Symbolics
+using Test
+
+@testset "Discrete initialization" begin
+    @independent_variables t
+    @parameters p
+    @variables u(t)[1:3] v(t)[1:2]
+    D = Differential(t)
+
+    eqs = [
+        D(u[1]) ~ 0,
+        D(u[2]) ~ v[1],
+        D(u[3]) ~ p,
+        v[1] ~ u[1],
+        v[2] ~ u[2],
+    ]
+    u0 = [
+        u[1] => 1.0,
+        u[2] => p,
+        u[3] => 3,
+        v[1] => p + 1,
+        v[2] => 5.0,
+    ]
+
+    init_eqs, guesses = PDEBase.discrete_initialization(eqs, t, u0)
+
+    @test length(init_eqs) == 3
+    @test Set(PDEBase.safe_unwrap(eq.lhs) for eq in init_eqs) ==
+        Set(PDEBase.safe_unwrap(x) for x in collect(u))
+    u2_init = only(eq for eq in init_eqs if isequal(eq.lhs, PDEBase.safe_unwrap(u[2])))
+    @test isequal(u2_init.rhs, PDEBase.safe_unwrap(p))
+
+    u_guesses = guesses[PDEBase.safe_unwrap(u)]
+    v_guesses = guesses[PDEBase.safe_unwrap(v)]
+    @test u_guesses[[1, 3]] == [1.0, 3]
+    @test isequal(u_guesses[2], PDEBase.safe_unwrap(p))
+    @test isequal(v_guesses[1], PDEBase.safe_unwrap(p + 1))
+    @test v_guesses[2] == 5.0
+    @test_nowarn System(
+        eqs, t, [u, v], [p];
+        initialization_eqs = init_eqs, guesses = guesses, name = :discrete_initialization_test
+    )
+
+    derivative_guesses = PDEBase.discrete_u0_to_atomic_map(
+        [D(u[1]) => 0.1, D(u[2]) => p, D(u[3]) => 0.3]
+    )
+    D_u = PDEBase.safe_unwrap(D(u))
+    @test derivative_guesses[D_u][[1, 3]] == [0.1, 0.3]
+    @test isequal(derivative_guesses[D_u][2], PDEBase.safe_unwrap(p))
+end

--- a/test/discrete_initialization.jl
+++ b/test/discrete_initialization.jl
@@ -24,7 +24,7 @@ using Test
         v[2] => 5.0,
     ]
 
-    init_eqs, guesses = PDEBase.discrete_initialization(eqs, t, u0)
+    init_eqs, guesses = PDEBase._discrete_initialization(eqs, t, u0)
 
     @test length(init_eqs) == 3
     @test Set(PDEBase.safe_unwrap(eq.lhs) for eq in init_eqs) ==
@@ -43,10 +43,15 @@ using Test
         initialization_eqs = init_eqs, guesses = guesses, name = :discrete_initialization_test
     )
 
-    derivative_guesses = PDEBase.discrete_u0_to_atomic_map(
-        [D(u[1]) => 0.1, D(u[2]) => p, D(u[3]) => 0.3]
+    second_order_eqs = [(D^2)(u[1]) ~ 0]
+    second_order_u0 = [u[1] => 1.0, D(u[1]) => p]
+    second_order_init, derivative_guesses = PDEBase._discrete_initialization(
+        second_order_eqs, t,
+        [second_order_u0; D(u[2]) => 0.2; D(u[3]) => 0.3]
     )
+    @test Set(PDEBase.safe_unwrap(eq.lhs) for eq in second_order_init) ==
+        Set(PDEBase.safe_unwrap(first(pair)) for pair in second_order_u0)
     D_u = PDEBase.safe_unwrap(D(u))
-    @test derivative_guesses[D_u][[1, 3]] == [0.1, 0.3]
-    @test isequal(derivative_guesses[D_u][2], PDEBase.safe_unwrap(p))
+    @test derivative_guesses[D_u][[2, 3]] == [0.2, 0.3]
+    @test isequal(derivative_guesses[D_u][1], PDEBase.safe_unwrap(p))
 end


### PR DESCRIPTION
## Summary

PDE discretizations (MethodOfLines via PDEBase) were not using ModelingToolkit's initialization system:

1. `ODEProblem(..., build_initializeprob=false)` disabled MTK init
2. Discrete grid ICs lived only in metadata / numeric `u0`, not on the `System`
3. MTK v11 `AtomicArrayDict` rejects indexed keys `(u(t))[i]`, so a naive dump into `initial_conditions` fails
4. Re-passing all indexed `u0` pairs as the ODEProblem operating point makes every grid value a **hard** IC and over-determines algebraic residuals

`DefaultInit` therefore fell through to `CheckInit`, which rejects O(h^k) discrete residuals of algebraically constrained states.

### Fix

- **`initialization_eqs`**: `var ~ val` only for unknowns that appear under `Differential(t)` (differential states — matches continuous IC structure)
- **`guesses`**: all discrete IC values as whole-array maps (algebraic nodes free, projected continuous IC as start guess)
- **`build_initializeprob=true`**: enable MTK init (`DefaultInit` → `OverrideInit`)
- **Do not re-pass indexed `u0`** as ODEProblem op (parameters only)

Helpers: `discrete_u0_to_atomic_map`, `variables_with_time_derivative`, `discrete_initialization`.

### Verification (with MethodOfLines develop-ing this branch)

| Case | Result |
|------|--------|
| PDAE Dirichlet (master CI failure) | Success + manufactured-solution accuracy |
| KdV single soliton (Higher_Order CI) | Success |
| Rearranged Robin (MOL_Interface1 CI) | Success |
| Pure diffusion | Success, UniformScaling mass matrix |
| `ENV[GROUP]=DAE` | 22/22 pass |
| `ENV[GROUP]=Higher_Order` | 1 pass, 2 broken (pre-existing) |
| `ENV[GROUP]=MOL_Interface1` | pass |

Version bump: `0.1.28` → `0.1.29`.

Follow-up: MethodOfLines staggered path + PDEBase compat bump (depends on this).

**Please ignore this PR until reviewed by @ChrisRackauckas.**