### PR TITLE
Drop PDEBase QA self source

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-PDEBase = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"


### PR DESCRIPTION
## Summary

- remove the redundant local `[sources]` entry from the QA environment
- rely on SciMLTesting's QA environment activation to develop the package under test by path

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Local validation

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. --startup-file=no -e 'using Pkg; Pkg.test(; coverage=false)'` passed (`QA/qa.jl | 18 pass, 1 broken, 19 total`)
- `rg -n '^\\[sources\\]|path\\s*=' test/qa/Project.toml` produced no matches
- `git diff --check` passed
