### PR TITLE
Release prep: bump version to 0.1.29

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.28"
+version = "0.1.29"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary
Bumps `PDEBase` version from 0.1.28 to 0.1.29 to pick up unreleased commits sitting on top of the last registered version.

## Changes since v0.1.28 (commit c2e3336)
- #94 "Drop PDEBase QA self source" — removed a `[sources]` self-path override (`PDEBase = {path = "../.."}`) from `test/qa/Project.toml`. This is a test-infrastructure-only change; no source files, public API, or `[compat]` bounds were touched.

## Bump type: PATCH (0.1.28 -> 0.1.29)
The only change since the last release is to test QA tooling configuration (removing a self-referencing `[sources]` entry used for local dev/test resolution). No new features, no API changes, no breaking changes, no dependency compat changes. This meets the criteria for a PATCH release.

## Compat bounds
Not touched — the diff doesn't add any new dependency usage or require raising any lower bounds; existing `[compat]` entries are already consistent with the code.