### PR TITLE
Remove stale NeuralPDE downstream jobs

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -26,8 +26,6 @@ jobs:
           - {user: SciML, repo: MethodOfLines.jl, group: Burgers}
           - {user: SciML, repo: MethodOfLines.jl, group: DAE}
           - {user: SciML, repo: PDESystemLibrary.jl, group: Core}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE1}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE2}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "1"


### PR DESCRIPTION
## Summary

- remove the two NeuralPDE matrix rows from PDEBase's downstream workflow
- keep the MethodOfLines and PDESystemLibrary jobs that actually depend on PDEBase

NeuralPDE no longer declares PDEBase as a dependency, so those rows could not load or exercise this package and provided misleading coverage.

## Local verification

- workflow-shaped Julia 1.12.6 `MethodOfLines/Components` run with PDEBase developed — exited 0; final line: `MethodOfLines tests passed`
- dependency audit confirmed no PDEBase UUID in NeuralPDE's project/test environments
- `actionlint .github/workflows/Downstream.yml` — passed
- `julia +1.12 -m Runic --check .` — passed
- `git diff --check` — passed

Please ignore this PR until it has been reviewed by @ChrisRackauckas.