### PR TITLE
Release PDEBase 0.1.32

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.31"
+version = "0.1.32"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

Bumps PDEBase from 0.1.31 to 0.1.32 so the array-dependent-variable fix merged in #101 can be registered.

Registered 0.1.31 contains the regression from #98: `@variables (u(..))[1:N]` is flattened into `Symbolics.Arr` values, and MethodOfLines then fails in `PDEBase.get_ops` with `MethodError: operation(::Symbolics.Arr)`. The code fix and regression test are already on `master`; this PR is only the patch release bump needed for downstream resolution.

This unblocks the `MethodOfLines.jl/MOL_Interface1` and `MethodOfLines.jl/MOL_Interface2` downstream failures observed in https://github.com/SciML/ModelingToolkit.jl/pull/4852.

## Version boundary

- General `PDEBase v0.1.30`: tree `a4f6532`, source commit `5b917e0` (before #98)
- General `PDEBase v0.1.31`: tree `04754fe`, source commit `97c9de5` (after #98, before #101)
- Fixed `master`: `01a7e79` (#101)

This is a patch release: it publishes a bug fix without changing public API or compatibility bounds.

## Local validation

Julia 1.12.6:

- Exact clean ModelingToolkit `d39174937` + MethodOfLines `5ec02a46`, registered PDEBase 0.1.31, `GROUP=MOL_Interface1`, `Pkg.test(coverage=true)`: reproduced exit 1 with only `MOLtest1.jl:231` (`Array u`) errored.
- Same resolved downstream manifest with only PDEBase changed to this 0.1.32 path: exit 0; `MOL_Interface1` completed in 12m50.8s and MethodOfLines tests passed.
- Exact clean ModelingToolkit `d39174937` + MethodOfLines `5ec02a46` + this PDEBase 0.1.32 path, `GROUP=MOL_Interface2`, `Pkg.test(coverage=true)`: 5 pass, 8 pre-existing broken, 13 total in 7m15.8s; MethodOfLines tests passed.
- `GROUP=Core`: 12/12 alloc, 11/11 array-variable regression, 18/18 discrete initialization, 46/46 public API.
- `GROUP=QA`: 20/20.
- Runic 1.7 `--check --diff`: clean.

Ignore until reviewed by @ChrisRackauckas.
