### PR TITLE
Fix documentation package compatibility

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,4 +6,4 @@ PDEBase = "a7812802-0625-4b9e-961c-d332478797e5"
 [compat]
 Documenter = "1"
 ModelingToolkit = "11"
-PDEBase = "0.2"
+PDEBase = "0.1"

--- a/test/docs_project.jl
+++ b/test/docs_project.jl
@@ -1,0 +1,8 @@
+using PDEBase
+using Test
+
+@testset "Documentation project" begin
+    version = pkgversion(PDEBase)
+    docs_project = read(joinpath(pkgdir(PDEBase), "docs", "Project.toml"), String)
+    @test contains(docs_project, "PDEBase = \"$(version.major).$(version.minor)\"")
+end


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Keep the documentation environment compatible with the package's current `0.1` version line.
- Add a Core regression test that derives the expected documentation compat from `pkgversion(PDEBase)`.

This is independent of #102. The release PR can change `0.1.31` to `0.1.32` without changing this documentation constraint.

## Root cause

On clean `upstream/master` at `01a7e79`, the reusable SciML documentation install command failed before the build:

```sh
julia +release --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
```

```text
ERROR: empty intersection between PDEBase@0.1.31 and project compatibility 0.2
```

The adjacent commit boundary identifies `97c9de5` as the first bad commit:

- Its parent, `1cf0ae2`, declares `PDEBase` version `0.2.0` in both the package and documentation projects. The exact install command succeeds there.
- `97c9de5` changes the package version to `0.1.31` but leaves the documentation compat at `0.2`.

Using `PDEBase = "0.1"` keeps documentation compatible across patch releases and avoids another edit for the pending `0.1.32` release.

## Local verification

- Julia 1.12, `GROUP=Core`: 88/88 passed
  - allocation 12/12
  - array variables 11/11
  - discrete initialization 18/18
  - documentation project regression 1/1
  - public API 46/46
- Julia 1.10, `GROUP=Core`: 73/73 passed
  - allocation 12/12
  - array variables 11/11
  - discrete initialization 18/18
  - documentation project regression 1/1
  - public API 31/31
- Julia 1.12, `GROUP=QA`: 20/20 passed.
- The exact reusable-workflow dependency install succeeds and selects local `PDEBase v0.1.31`.
- `julia +release --project=docs/ --code-coverage=user docs/make.jl` completes doctests, document checks, and HTML rendering with exit code 0. Local deployment is skipped because no CI deployment environment is present.
- Runic 1.7.0: whole-repository `--check` exits 0.

As a control, the same Julia 1.10 Core command passes on clean `upstream/master`; no additional clean-master test failure was found.
