### PR TITLE
docs: specify PDEBase extension interfaces

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -148,7 +148,7 @@ Tracks which variables have periodic boundary conditions.
 
 ## Interface Functions
 
-For detailed documentation of interface functions, see [Developer Extension API](@ref developer-extension-api).
+For detailed documentation of interface functions, see [Developer Extension API](interface.md).
 
 ### Summary
 

--- a/docs/src/boundaries.md
+++ b/docs/src/boundaries.md
@@ -266,6 +266,6 @@ This is used to determine when to wrap grid indices in finite difference stencil
 
 ## See Also
 
-- [Developer Extension API](@ref developer-extension-api) for how boundaries integrate with discretization
+- [Developer Extension API](interface.md) for how boundaries integrate with discretization
 - [Discretization Workflow](@ref workflow) for the complete processing pipeline
 - [VariableMap](@ref variablemap) for variable handling

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -175,7 +175,7 @@ end
 
 ## Next Steps
 
-- Read the [Developer Extension API](@ref developer-extension-api) for detailed interface documentation
+- Read the [Developer Extension API](interface.md) for detailed interface documentation
 - Study [VariableMap](@ref variablemap) to understand variable handling
 - Review [Boundary Conditions](@ref boundaries) for BC types
 - See [Discretization Workflow](@ref workflow) for the complete pipeline

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,7 +34,7 @@ PDEBase defines how a `ModelingToolkit.PDESystem` is converted into a discretize
 - Boundary conditions specified at domain boundaries
 - Initial conditions for time-dependent problems
 
-See [Developer Extension API](@ref developer-extension-api) for complete details.
+See [Developer Extension API](interface.md) for complete details.
 
 ### The Discretization Workflow
 

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -1,101 +1,115 @@
-# [Developer Extension API](@id developer-extension-api)
+# [Developer Extension API](@id developer_extension_api)
 
-PDEBase.jl provides the versioned interface that discretization packages implement to convert a `ModelingToolkit.PDESystem` into a discretized system (typically an `ODESystem` or `OptimizationSystem`).
+PDEBase defines a small, versioned protocol for packages that discretize a
+`ModelingToolkit.PDESystem`. The protocol turns symbolic equations and boundary
+conditions into a symbolic ODE, DAE, or optimization system. It is an extension
+API for discretizer authors, not an application-level solver API.
 
-!!! warning "Developer API, not ordinary user API"
+!!! warning "Developer API"
 
-    These qualified hooks are for PDE discretizer authors. They are documented
-    and versioned so extension packages can depend on them, but applications
-    should use a discretizer such as MethodOfLines.jl rather than call or
-    extend this protocol directly.
+    The functions on this page are public so that discretizer packages can
+    extend them. Ordinary applications should call a discretizer such as
+    MethodOfLines.jl and should not build a solver directly on these hooks.
+    Extension packages should preserve the call order and return contracts below.
 
-## Key Assumptions about PDESystem
+## Contract
 
-When working with PDEBase.jl, the following assumptions are made about the input `PDESystem`:
+The generic pipeline calls the hooks in this order:
 
-### Domain Requirements
-- The PDESystem must have a well-defined domain with intervals for all independent variables
-- Domain boundaries must be finite (using `DomainSets.jl` interval notation)
-- Each independent variable must have exactly one domain interval defined
+1. `VariableMap(pdesys, discretization)` normalizes symbolic variables and
+   domains.
+2. `interface_errors` rejects unsupported systems before work is allocated.
+3. `parse_bcs` creates the boundary map, then `check_boundarymap` validates it.
+4. `should_transform` optionally enables `transform_pde_system!`.
+5. `construct_disc_state`, `construct_discrete_space`, and
+   `construct_var_equation_mapping` create the discretizer state.
+6. `construct_differential_discretizer` precomputes derivative data.
+7. For each PDE, `get_eqvar` selects its discrete variable and
+   `discretize_equation!` updates the state in place.
+8. `generate_ic_defaults` creates discrete initial values.
+9. `generate_metadata` stores data needed by the generated problem and solution.
+10. `generate_system` constructs the final symbolic system.
 
-### Variable Requirements
-- **Dependent variables** (e.g., `u(t,x,y)`) are functions of independent variables
-- **Independent variables** include spatial variables (e.g., `x`, `y`, `z`) and optionally a time variable
-- All dependent variables appearing in equations must be registered in the PDESystem
-- Variable arguments must be consistent across all uses (e.g., `u(t,x)` cannot appear as `u(x,t)` elsewhere)
+The default methods are intentionally conservative no-ops. A production
+discretizer must override the hooks that construct its space, map, derivative
+data, equations, metadata, and final system. A hook should return only the value
+specified in its docstring; in-place hooks should mutate their supplied state
+and return `nothing`.
 
-### Equation Requirements
-- The system must include PDEs (partial differential equations) as the main equations
-- Boundary conditions must be specified for all spatial boundaries
-- Initial conditions are required if the system is time-dependent
-- All boundary conditions must be defined at the domain boundaries (not in the interior)
+## Input Rules
 
-### Boundary Condition Requirements
-- Each dependent variable must have boundary conditions for each spatial dimension
-- Boundary conditions must evaluate on the lower or upper bound of each spatial domain
-- Interface conditions (connecting multiple regions) must be properly structured
-- Periodic boundary conditions must appear in pairs (lower and upper)
+The `PDESystem` supplied to the protocol is expected to satisfy these rules:
+
+- Every independent variable has one finite domain interval.
+- Dependent variables use a consistent argument order throughout equations and
+  boundary conditions.
+- Every spatial boundary required by the discretizer is represented in the
+  boundary conditions.
+- Time-dependent systems provide initial conditions on the time variable.
+- Periodic conditions occur as matching lower/upper pairs.
+- Interface conditions connect variables with compatible argument signatures;
+  only the interface coordinate may differ.
+
+`VariableMap` excludes time from `indvars(v)` but retains it in `all_ivs(v)` and
+in each dependent variable's argument signature. A discretizer should use the
+accessors rather than infer dimension order from a field layout.
 
 ## Abstract Types
 
-PDEBase.jl defines several abstract types that discretization packages should subtype:
-
-### Discretization Types
-
-```julia
-abstract type AbstractEquationSystemDiscretization <: AbstractDiscretization end
-```
-Use this as a supertype for discretizations that produce systems of ODEs or DAEs.
+Discretizers should subtype one of the output categories and the supporting
+abstract types as appropriate:
 
 ```julia
-abstract type AbstractOptimizationSystemDiscretization <: AbstractDiscretization end
+struct MyDiscretization <: PDEBase.AbstractEquationSystemDiscretization
+    kwargs::NamedTuple
+end
+
+struct MySpace <: PDEBase.AbstractCartesianDiscreteSpace
+    grid::Vector{Float64}
+end
+
+struct MyMapping <: PDEBase.AbstractVarEqMapping
+    equation_variables::Dict
+end
+
+struct MyDerivativeData <: PDEBase.AbstractDifferentialDiscretizer
+    weights::Dict
+end
+
+struct MyState <: PDEBase.AbstractDiscretizationState
+    equations::Vector
+end
 ```
-Use this for discretizations targeting optimization problems (e.g., optimal control).
 
-### Space Representation Types
+`AbstractEquationSystemDiscretization` is for ODE/DAE-like symbolic systems;
+`AbstractOptimizationSystemDiscretization` is for optimization systems.
+`AbstractDiscreteSpace`, `AbstractVarEqMapping`,
+`AbstractDifferentialDiscretizer`, and `AbstractDiscretizationState` describe
+the values exchanged by the protocol and are intentionally free of concrete
+mesh or solver assumptions.
 
-```julia
-abstract type AbstractDiscreteSpace end
-abstract type AbstractCartesianDiscreteSpace <: AbstractDiscreteSpace end
-```
-These represent the discretized spatial domain. `AbstractCartesianDiscreteSpace` is for regular Cartesian grids.
+## Validation and Transformation
 
-### Auxiliary Types
-
-```julia
-abstract type AbstractVarEqMapping end
-```
-Maps variables to the equations they are solved from.
-
-```julia
-abstract type AbstractDifferentialDiscretizer end
-```
-Stores information needed to discretize differential operators.
-
-```julia
-abstract type AbstractDiscretizationState end
-```
-Holds mutable state during the discretization process.
-
-## Interface Functions to Implement
-
-To create a new discretization package, you must implement the following interface functions. Default implementations are provided that return `nothing`, but most must be overridden for a functional discretizer.
-
-### Validation Functions
+These hooks run before equation generation. Validation hooks should throw a
+domain-specific error for unsupported input and return `nothing` for valid
+input. `should_transform` must be a pure decision for the supplied system;
+`transform_pde_system!` is called only when it returns `true` and must return the
+system consumed by later hooks.
 
 ```@docs
 PDEBase.interface_errors
 PDEBase.check_boundarymap
-```
-
-### Transformation Functions
-
-```@docs
 PDEBase.should_transform
 PDEBase.transform_pde_system!
 ```
 
-### Construction Functions
+## Construction
+
+Construction hooks establish the values shared by every equation visit. The
+mapping returned by `construct_var_equation_mapping` must support
+`get_eqvar` for every PDE, and the derivative data returned by
+`construct_differential_discretizer` must support every derivative order listed
+in `orders`.
 
 ```@docs
 PDEBase.construct_disc_state
@@ -104,21 +118,24 @@ PDEBase.construct_var_equation_mapping
 PDEBase.construct_differential_discretizer
 ```
 
-### Discretization Functions
+## Equation and Finalization Hooks
+
+`discretize_equation!` is the only per-equation hook. It should append or mutate
+the state and leave system construction to `generate_system`. The finalization
+hooks should keep the metadata and initial-value representations consistent;
+`generate_system` receives the `checks` keyword and should forward it to the
+symbolic system constructor.
 
 ```@docs
 PDEBase.discretize_equation!
 PDEBase.generate_ic_defaults
-```
-
-### Finalization Functions
-
-```@docs
 PDEBase.generate_metadata
 PDEBase.generate_system
 ```
 
-### Utility Functions
+## Accessor Hooks
+
+These accessors keep downstream packages independent of concrete field names:
 
 ```@docs
 PDEBase.get_time
@@ -127,68 +144,42 @@ PDEBase.get_eqvar
 PDEBase.add_metadata!
 ```
 
-## Implementation Example
+## Minimal Implementation
 
-Here is a minimal skeleton for implementing a new discretization:
+The following skeleton shows the intended generic dispatch. A real package must
+also implement the numerical work inside `discretize_equation!` and construct a
+concrete symbolic system in `generate_system`.
 
 ```julia
-using PDEBase, ModelingToolkit, SciMLBase
+using PDEBase
 
-# Define your discretization type
 struct MyDiscretization <: PDEBase.AbstractEquationSystemDiscretization
-    dx::Float64  # grid spacing
-    # ... other parameters
+    time::Any
 end
 
-# Define your discrete space
-struct MyDiscreteSpace <: PDEBase.AbstractCartesianDiscreteSpace
+struct MySpace <: PDEBase.AbstractCartesianDiscreteSpace
     grid::Vector{Float64}
-    vars::Dict
-    # ... other fields
 end
 
-# Implement required interface functions
-function PDEBase.construct_discrete_space(v::PDEBase.VariableMap, disc::MyDiscretization)
-    # Build the discrete grid and variables
-    # ...
-    return MyDiscreteSpace(grid, vars)
+PDEBase.get_time(disc::MyDiscretization) = disc.time
+PDEBase.construct_discrete_space(v, ::MyDiscretization) = MySpace(collect(0:0.1:1))
+
+function PDEBase.construct_var_equation_mapping(eqs, bmap, space::MySpace,
+        disc::MyDiscretization)
+    return MyMapping(Dict(eq => space.grid for eq in eqs))
 end
 
-function PDEBase.discretize_equation!(
-    disc_state,
-    pde::Equation,
-    vareqmap,
-    eqvar,
-    bcmap,
-    depvars,
-    s::MyDiscreteSpace,
-    derivweights,
-    indexmap,
-    disc::MyDiscretization
-)
-    # Convert the PDE to discretized equations
-    # Add equations to disc_state
-    # ...
-end
-
-function PDEBase.generate_system(
-    disc_state,
-    s::MyDiscreteSpace,
-    u0,
-    tspan,
-    metadata,
-    disc::MyDiscretization
-)
-    # Combine all equations into an ODESystem or similar
-    # Extract time variable and build system
-    t = PDEBase.get_time(disc)
-    # eqs = ... (build equations from disc_state)
-    return ODESystem(eqs, t; name=:discretized)
+function PDEBase.discretize_equation!(state, pde, mapping, eqvar, bcmap,
+        depvars, space, derivative_data, indexmap, disc)
+    push!(state.equations, pde)
+    return nothing
 end
 ```
 
-## See Also
+The generic interface tests in PDEBase exercise the default methods and a
+minimal concrete dispatch using only these hooks. New discretizers should add a
+similar contract test for their concrete invariants.
 
-- [Discretization Workflow](@ref workflow) for the complete processing pipeline
-- [VariableMap](@ref variablemap) for understanding variable handling
-- [Boundary Conditions](@ref boundaries) for boundary condition types
+See the [Discretization Workflow](@ref workflow) for the data flow and the
+[VariableMap](@ref variablemap) and [Boundary Conditions](@ref boundaries)
+pages for the symbolic input structures.

--- a/docs/src/variablemap.md
+++ b/docs/src/variablemap.md
@@ -199,5 +199,5 @@ Returns axis values at grid positions. Used internally during discretization.
 
 ## See Also
 
-- [Developer Extension API](@ref developer-extension-api) for how VariableMap is used in discretization
+- [Developer Extension API](interface.md) for how VariableMap is used in discretization
 - [Boundary Conditions](@ref boundaries) for how boundaries reference variables

--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -257,6 +257,6 @@ Implement these in your discretization to provide helpful error messages.
 
 ## See Also
 
-- [Developer Extension API](@ref developer-extension-api) for interface function details
+- [Developer Extension API](interface.md) for interface function details
 - [VariableMap](@ref variablemap) for variable handling
 - [Boundary Conditions](@ref boundaries) for boundary types

--- a/src/PDEBase.jl
+++ b/src/PDEBase.jl
@@ -25,6 +25,9 @@ using TermInterface: maketerm, metadata
 
 Supertype for discretizations that lower a `PDESystem` into an equation-based
 SciML system, typically an `ODESystem` or `DAESystem`.
+
+Discretizer packages subtype this type and implement the developer extension
+hooks documented in the [Developer Extension API](@ref developer_extension_api).
 """
 abstract type AbstractEquationSystemDiscretization <: AbstractDiscretization end
 
@@ -33,6 +36,9 @@ abstract type AbstractEquationSystemDiscretization <: AbstractDiscretization end
 
 Supertype for discretizations that lower a `PDESystem` into an optimization
 system.
+
+Use this type when the generated system is consumed by an optimization problem
+rather than by an ODE or DAE solver.
 """
 abstract type AbstractOptimizationSystemDiscretization <: AbstractDiscretization end
 
@@ -41,6 +47,9 @@ abstract type AbstractOptimizationSystemDiscretization <: AbstractDiscretization
 
 Supertype for discretized spatial domain representations produced from a
 `PDESystem` and a discretization.
+
+Concrete spaces are returned by `construct_discrete_space` and are passed to
+the remaining discretization hooks.
 """
 abstract type AbstractDiscreteSpace end
 
@@ -49,6 +58,9 @@ abstract type AbstractDiscreteSpace end
 
 Supertype for discrete space representations whose coordinates form a
 Cartesian product grid.
+
+Subtype this type when `x2i` and Cartesian indexing describe the spatial
+coordinates without a general mesh connectivity object.
 """
 abstract type AbstractCartesianDiscreteSpace <: AbstractDiscreteSpace end
 
@@ -57,6 +69,9 @@ abstract type AbstractCartesianDiscreteSpace <: AbstractDiscreteSpace end
 
 Supertype for mappings that assign dependent variables and boundary conditions
 to the equations used to discretize them.
+
+Concrete mappings are returned by `construct_var_equation_mapping`; their
+`get_eqvar` method must identify the discrete variable for every PDE.
 """
 abstract type AbstractVarEqMapping end
 
@@ -65,6 +80,9 @@ abstract type AbstractVarEqMapping end
 
 Supertype for objects that hold the data needed to discretize differential
 operators on a discrete space.
+
+Concrete derivative data is returned by `construct_differential_discretizer`
+and consumed by `discretize_equation!`.
 """
 abstract type AbstractDifferentialDiscretizer end
 
@@ -73,6 +91,9 @@ abstract type AbstractDifferentialDiscretizer end
 
 Supertype for mutable state accumulated while PDE equations and boundary
 conditions are discretized.
+
+Concrete state is returned by `construct_disc_state` and is updated in place by
+`discretize_equation!` before `generate_system` consumes it.
 """
 abstract type AbstractDiscretizationState end
 

--- a/src/interface_defaults.jl
+++ b/src/interface_defaults.jl
@@ -5,29 +5,105 @@
 """
     interface_errors(sys::PDESystem, v::VariableMap, disc::AbstractDiscretization)
 
-Use this function to check that your discretization type can discretize the given PDESystem.
+Check whether `disc` supports the structure of `sys` represented by `v`.
+
+Discretization packages should extend this function with checks for features that
+cannot be handled by their implementation. Return `nothing` when the system is
+supported; otherwise throw an informative exception before any boundary parsing
+or discretization work begins.
+
+# Arguments
+- `sys::PDESystem`: The PDE system being discretized.
+- `v::VariableMap`: The variable map constructed from `sys`.
+- `disc::AbstractDiscretization`: The discretization being applied.
+
+# Returns
+- `nothing`: The system is supported.
+
+# Examples
+```julia
+function PDEBase.interface_errors(sys, v, disc::MyDiscretization)
+    isempty(v.x̄) && throw(ArgumentError("MyDiscretization requires a spatial variable"))
+    return nothing
+end
+```
 """
 interface_errors(sys::PDESystem, v::VariableMap, disc::AbstractDiscretization) = nothing
 
 """
     check_boundarymap(bmap, v::VariableMap, disc::AbstractDiscretization)
 
-Once the boundaries have been parsed, check that they are valid for the given discretization.
+Validate the parsed boundary map before discretizing equations.
+
+Extend this function when a discretizer imposes requirements beyond the
+`PDESystem` boundary syntax, such as requiring both sides of every spatial
+dimension. The map is the nested representation produced by PDEBase, with
+dependent-variable operations at the outer level and independent variables at
+the inner level.
+
+# Arguments
+- `bmap`: The parsed boundary map.
+- `v::VariableMap`: The variable map for the PDE system.
+- `disc::AbstractDiscretization`: The discretization being applied.
+
+# Returns
+- `nothing`: The boundary map is valid.
+
+# Examples
+```julia
+function PDEBase.check_boundarymap(bmap, v, disc::MyDiscretization)
+    isempty(PDEBase.flatten_vardict(bmap)) &&
+        throw(ArgumentError("MyDiscretization requires boundary conditions"))
+    return nothing
+end
+```
 """
 check_boundarymap(bmap, v::VariableMap, disc::AbstractDiscretization) = nothing
 
 """
-    should_transform(pdesys::PDESystem, disc::AbstractDiscretization)
+    should_transform(pdesys::PDESystem, disc::AbstractDiscretization, boundarymap)
 
-Boolean function that determines whether a PDESystem should be transformed to
-make it compatible with the given discretization.
+Report whether `pdesys` must be transformed before discretization.
+
+This hook is called after boundary validation. A `true` result must be paired
+with a `transform_pde_system!` method for the same discretizer; a `false` result
+leaves the original system unchanged.
+
+# Arguments
+- `pdesys::PDESystem`: The validated PDE system.
+- `disc::AbstractDiscretization`: The discretization being applied.
+- `boundarymap`: The parsed boundary map.
+
+# Returns
+- `Bool`: `true` when the transformation hook should run, otherwise `false`.
 """
 should_transform(pdesys::PDESystem, disc::AbstractDiscretization, boundarymap) = false
 
 """
     transform_pde_system!(v::VariableMap, boundarymap, pdesys::PDESystem, disc::AbstractDiscretization)
 
-Transforms the PDESystem to make it compatible with the given discretization.
+Transform a PDE system into the representation required by `disc`.
+
+This hook is called only when `should_transform` returns `true`. Update or
+replace the system consistently with `v` and `boundarymap`; the returned system
+is used for all subsequent interface calls. A transformation must preserve the
+meaning of the equations and boundary conditions.
+
+# Arguments
+- `v::VariableMap`: The variable map built before transformation.
+- `boundarymap`: The parsed boundary map associated with `pdesys`.
+- `pdesys::PDESystem`: The system to transform.
+- `disc::AbstractDiscretization`: The discretization that will consume it.
+
+# Returns
+- `PDESystem`: The transformed system passed to the construction hooks.
+
+# Examples
+```julia
+function PDEBase.transform_pde_system!(v, boundarymap, pdesys, disc::MyDiscretization)
+    return rebuild_for_my_backend(pdesys)
+end
+```
 """
 function transform_pde_system!(
         v::VariableMap, boundarymap,
@@ -39,8 +115,26 @@ end
 """
     construct_disc_state(disc::AbstractDiscretization)
 
-Constructs the container which will hold all information needed to construct
-the discretized PDESystem. Must be mutable, or contain mutables.
+Construct the mutable state that accumulates discretized equations.
+
+The returned object is passed to `discretize_equation!` for every PDE and then
+to `generate_system`. It must be mutable itself or contain mutable fields that
+can hold the generated interior and boundary equations.
+
+# Arguments
+- `disc::AbstractDiscretization`: The discretization being applied.
+
+# Returns
+- `AbstractDiscretizationState`: State consumed by the discretization hooks.
+
+# Examples
+```julia
+struct MyState <: PDEBase.AbstractDiscretizationState
+    equations::Vector
+end
+
+PDEBase.construct_disc_state(::MyDiscretization) = MyState(Any[])
+```
 """
 construct_disc_state(::AbstractDiscretization) = []
 
@@ -49,23 +143,46 @@ construct_disc_state(::AbstractEquationSystemDiscretization) = EquationState()
 """
     construct_discrete_space(v::VariableMap, disc::AbstractDiscretization)
 
-Constructs the discrete space representation for the given discretization.
+Construct the discrete spatial representation used by a discretizer.
 
 # Arguments
-- `v::VariableMap`: The variable map containing dependent and independent variables
-- `disc::AbstractDiscretization`: The discretization scheme
+- `v::VariableMap`: The variable map containing the dependent and independent variables.
+- `disc::AbstractDiscretization`: The discretization scheme.
 
 # Returns
-An instance of `AbstractDiscreteSpace` containing the discretized spatial domain information.
+- `AbstractDiscreteSpace`: A grid or mesh representation and any associated
+  discrete variables.
+
+# Examples
+```julia
+struct MySpace <: PDEBase.AbstractCartesianDiscreteSpace
+    grid::Vector{Float64}
+end
+
+PDEBase.construct_discrete_space(v, ::MyDiscretization) = MySpace(collect(0:0.1:1))
+```
 """
 construct_discrete_space(v::VariableMap, disc::AbstractDiscretization) = nothing
 
 """
     construct_var_equation_mapping(pdeeqs, bmap, s::AbstractDiscreteSpace, disc::AbstractDiscretization)
 
-Constructs the mapping from the variables in the PDESystem to which equations they are solved from,
-given the equations, boundary conditions, and discretization. This is a good time to calculate any
-extra information needed for the boundary condition handling.
+Construct the mapping from each PDE to the discrete variable it determines.
+
+The mapping is also the place to precompute information needed when boundary
+conditions are applied. `get_eqvar` must be able to retrieve the variable for
+each equation in `pdeeqs` from the returned object.
+
+# Arguments
+- `pdeeqs`: The PDE equations after any optional transformation.
+- `bmap`: The parsed boundary map.
+- `s::AbstractDiscreteSpace`: The discrete space returned by
+  `construct_discrete_space`.
+- `disc::AbstractDiscretization`: The discretization scheme.
+
+# Returns
+- `AbstractVarEqMapping`: A mapping consumed by `get_eqvar` and
+  `discretize_equation!`.
 """
 function construct_var_equation_mapping(
         pdeeqs, bmap,
@@ -79,23 +196,51 @@ end
     construct_differential_discretizer(pdesys::PDESystem, s::AbstractDiscreteSpace,
                                        disc::AbstractDiscretization, orders)
 
-Constructs the differential discretizer for the given discretization, given the orders of
-derivative for each independent variable that are present in the PDESystem.
+Construct the derivative approximation data for `disc`.
 
-This is a type useful for doing any precalculations that are needed for the discretization.
+`orders` maps each independent variable to the derivative orders appearing in
+the PDE and boundary conditions. This hook is where a discretizer should do
+precomputation such as finite-difference weights or element-local operators.
+
+# Arguments
+- `pdesys::PDESystem`: The transformed PDE system.
+- `s::AbstractDiscreteSpace`: The discrete space on which derivatives act.
+- `disc::AbstractDiscretization`: The discretization scheme.
+- `orders`: A map from independent variables to required derivative orders.
+
+# Returns
+- `AbstractDifferentialDiscretizer`: Derivative data consumed by
+  `discretize_equation!`.
 """
 construct_differential_discretizer(pdesys, s, discretization, orders) = nothing
 
 """
-    discretize_equation!(disc_state::AbstractDiscretizationState, pde::Equation, vareqmap::AbstractVarEqMap,
+    discretize_equation!(disc_state::AbstractDiscretizationState, pde::Equation, vareqmap::AbstractVarEqMapping,
                          eqvar, bcmap, depvars, s::AbstractDiscreteSpace,
                          derivweights::AbstractDifferentialDiscretizer, indexmap, discretization::AbstractDiscretization)
-Add the information from the given pde equation to the discretization state. Also, discretize the bcs associated with the eqvar.
+Add one PDE and its associated spatial boundary conditions to `disc_state`.
 
-eqvar: the variable that this equation is for, contains all free ivs in the equation.
-bcmap: boundarymap with any conditions on time removed.
-depvars: the dependent variables in the equation.
-indexmap: dict mapping each iv in this equation to its index in the eqvar.
+This hook is called once for every PDE after the equation-to-variable mapping
+has been built. It should append or mutate the discrete interior and boundary
+equations in `disc_state`; it should not construct the final symbolic system.
+
+# Arguments
+- `disc_state::AbstractDiscretizationState`: Accumulator returned by
+  `construct_disc_state`.
+- `pde::Equation`: The PDE equation currently being discretized.
+- `vareqmap::AbstractVarEqMapping`: Mapping returned by
+  `construct_var_equation_mapping`.
+- `eqvar`: The discrete variable solved for by `pde`.
+- `bcmap`: Boundary map with conditions on the time variable removed.
+- `depvars`: Dependent variables appearing in `pde`.
+- `s::AbstractDiscreteSpace`: The discrete space.
+- `derivweights::AbstractDifferentialDiscretizer`: Derivative data returned by
+  `construct_differential_discretizer`.
+- `indexmap`: Map from each independent variable in `eqvar` to its index.
+- `discretization::AbstractDiscretization`: The active discretization.
+
+# Returns
+- `nothing`: The state is updated in place.
 """
 function discretize_equation!(
         disc_state::AbstractDiscretizationState, pde::Equation,
@@ -110,34 +255,80 @@ end
 """
     generate_ic_defaults(ics, s::AbstractDiscreteSpace, disc::AbstractDiscretization)
 
-Generate the default initial conditions for the given discretization. This is a good time to check
-that the initial conditions are valid for the given discretization.
+Generate discrete initial-condition values and validate the input conditions.
 
 # Arguments
-- `ics`: A list of all conditions on the time variable
-- `s::AbstractDiscreteSpace`: The discrete space
-- `disc::AbstractDiscretization`: The discretization
+- `ics`: Conditions on the time variable extracted from the boundary map.
+- `s::AbstractDiscreteSpace`: The discrete space.
+- `disc::AbstractDiscretization`: The discretization.
+
+# Returns
+- `u0`: Initial values in the representation expected by `generate_system`.
+
+# Examples
+```julia
+PDEBase.generate_ic_defaults(ics, space::MySpace, ::MyDiscretization) =
+    [evaluate_initial_condition(ic, space) for ic in ics]
+```
 """
 generate_ic_defaults(ics, s::AbstractDiscreteSpace, disc::AbstractDiscretization) = nothing
 
 """
     generate_metadata(s, discretization, pdesys, boundarymap, complexmap, u0)
 
-Generate the metadata for the discretization. This can be used to store any extra information that
-may be needed to convert the system in to a problem, or to reshape the solution once it is solved.
-It is a good idea for this to return a subtype of SciMLBase.AbstractDiscretizationMetadata.
-u0: the discretized initial conditions (for MTK v11 compatibility, these need to be stored separately)
+Create metadata needed to construct a problem or reconstruct a solution.
+
+The metadata is passed unchanged to `generate_system`. Returning a subtype of
+`SciMLBase.AbstractDiscretizationMetadata` allows the generic
+`add_metadata!` hook to attach the original symbolic system.
+
+# Arguments
+- `s`: The discrete space.
+- `discretization`: The active discretization.
+- `pdesys`: The transformed PDE system.
+- `boundarymap`: The parsed boundary map.
+- `complexmap`: The map used while normalizing complex equations.
+- `u0`: The discrete initial conditions returned by `generate_ic_defaults`.
+
+# Returns
+- `AbstractDiscretizationMetadata`: Metadata consumed by `generate_system`.
 """
 generate_metadata(s, discretization, pdesys, boundarymap, complexmap, u0 = []) = nothing
 
 """
     generate_system(disc_state::AbstractDiscretizationState, s::AbstractDiscreteSpace, u0, tspan, metadata::AbstractDiscretizationMetadata, discretization::AbstractDiscretization)
 
-Generate the discretized system from the discretization state, the discretization, and the metadata.
-You likely want this to return one of the symbolic system types from ModelingToolkit.jl.
-u0: the return value of generate_ic_defaults
-tspan: the time span of the problem, if relevant. (else nothing)
-checks is passed to the system constructor.
+Build the final symbolic system from the accumulated discretization results.
+
+The returned value is passed back through `SciMLBase.symbolic_discretize`; in
+the usual time-dependent case it is a tuple `(system, tspan)`. Use `checks` when
+constructing the symbolic system and forward it to the constructor rather than
+silently changing validation behavior.
+
+# Arguments
+- `disc_state::AbstractDiscretizationState`: State populated by
+  `discretize_equation!`.
+- `s::AbstractDiscreteSpace`: The discrete space.
+- `u0`: Initial values returned by `generate_ic_defaults`.
+- `tspan`: The time interval, or `nothing` for a steady-state system.
+- `metadata::AbstractDiscretizationMetadata`: Metadata returned by
+  `generate_metadata`.
+- `discretization::AbstractDiscretization`: The active discretization.
+
+# Keywords
+- `checks::Bool = true`: Enable symbolic-system consistency checks.
+
+# Returns
+- `Tuple`: The generated symbolic system and its time span.
+
+# Examples
+```julia
+function PDEBase.generate_system(state, space, u0, tspan, metadata,
+        disc::MyDiscretization; checks = true)
+    system = ODESystem(state.equations, get_time(disc); checks)
+    return system, tspan
+end
+```
 """
 function generate_system(
         disc_state::AbstractDiscretizationState, s::AbstractDiscreteSpace,
@@ -154,7 +345,17 @@ end
 """
     get_time(discretization::AbstractDiscretization)
 
-Get the time variable for the given discretization.
+Return the independent time variable used by `discretization`.
+
+Return `nothing` for steady-state discretizations. The result is used to
+separate initial conditions from spatial boundary conditions and to determine
+whether the generated system is time dependent.
+
+# Arguments
+- `discretization::AbstractDiscretization`: The discretization being applied.
+
+# Returns
+- A symbolic time variable, or `nothing` for a steady-state discretization.
 """
 get_time(discretization::AbstractDiscretization) = nothing
 get_time(_) = nothing
@@ -166,7 +367,17 @@ get_time(_) = nothing
 """
     get_discvars(s::AbstractDiscreteSpace)
 
-Get the discrete variable map, where relevant
+Return the discrete variables associated with `s`.
+
+The result is consumed by the final system constructor to identify the unknowns
+created by the discretizer. Discretizations without a separate variable map
+may return an empty collection.
+
+# Arguments
+- `s::AbstractDiscreteSpace`: The discrete space.
+
+# Returns
+- A collection or map of symbolic discrete variables.
 """
 get_discvars(s::AbstractDiscreteSpace) = []
 
@@ -174,9 +385,21 @@ get_discvars(s::AbstractDiscreteSpace) = []
 # Default interface functions for `AbstractVarEqMapping`
 ############################################################################################
 """
-    get_eqvar(vareqmap::AbstractVarEqMapping)
+    get_eqvar(vareqmap::AbstractVarEqMapping, eq)
 
-Get the variable that the given equation will be solved for.
+Return the discrete variable solved for by equation `eq`.
+
+Every equation passed to `discretize_equation!` must have a corresponding
+variable. The returned variable must use the same independent-variable ordering
+that `ivs` and `x2i` expect for the associated `VariableMap`.
+
+# Arguments
+- `vareqmap::AbstractVarEqMapping`: Mapping returned by
+  `construct_var_equation_mapping`.
+- `eq`: The PDE equation being visited.
+
+# Returns
+- The discrete dependent variable associated with `eq`.
 """
 get_eqvar(vareqmap::AbstractVarEqMapping, eq) = nothing
 
@@ -185,6 +408,19 @@ get_eqvar(vareqmap::AbstractVarEqMapping, eq) = nothing
 ############################################################################################
 """
     add_metadata!(metadata::AbstractDiscretizationMetadata, value)
+
+Attach `value` to the mutable metadata slot in `metadata`.
+
+This hook is used by PDEBase to retain the original symbolic system after a
+compiled system is built. Metadata implementations should provide a mutable
+`metadata` field, typically a `Ref`, when they use the default method.
+
+# Arguments
+- `metadata::AbstractDiscretizationMetadata`: Metadata object to update.
+- `value`: Value to store in its metadata slot.
+
+# Returns
+- The assigned `value`.
 """
 function add_metadata!(metadata::AbstractDiscretizationMetadata, value)
     return metadata.metadata[] = value

--- a/src/parse_boundaries.jl
+++ b/src/parse_boundaries.jl
@@ -28,6 +28,10 @@ abstract type AbstractInterfaceBoundary <: AbstractTruncatingBoundary end
 
 Represents a boundary condition at the lower boundary of a domain.
 
+The public fields describe the boundary after PDEBase has matched the input
+condition to a dependent variable and spatial coordinate. Construct instances
+through `LowerBoundary(u, t, x, order, eq, v)` while parsing a `PDESystem`.
+
 # Fields
 - `u`: The dependent variable
 - `x`: The independent variable at this boundary
@@ -35,6 +39,23 @@ Represents a boundary condition at the lower boundary of a domain.
 - `indvars`: All independent variables involved in the boundary condition
 - `eq`: The boundary condition equation
 - `order`: The order of the derivative in the boundary condition
+
+# Arguments
+- `u`: The dependent-variable expression at the boundary.
+- `t`: The time variable, or `nothing` for a steady-state system.
+- `x`: The independent variable whose lower endpoint is represented.
+- `order`: The derivative order associated with the boundary condition.
+- `eq`: The symbolic boundary equation.
+- `v::VariableMap`: The variable map used to reconstruct dependent variables.
+
+# Returns
+- `LowerBoundary`: A normalized boundary representation.
+
+# Examples
+```julia
+boundary = LowerBoundary(u(t, 0), t, x, 0, u(t, 0) ~ 0, v)
+boundary.x == x
+```
 """
 struct LowerBoundary <: AbstractTruncatingBoundary
     u::Any
@@ -63,6 +84,9 @@ end
 
 Represents a boundary condition at the upper boundary of a domain.
 
+Construct instances through `UpperBoundary(u, t, x, order, eq, v)` while
+parsing a `PDESystem`.
+
 # Fields
 - `u`: The dependent variable
 - `x`: The independent variable at this boundary
@@ -70,6 +94,23 @@ Represents a boundary condition at the upper boundary of a domain.
 - `indvars`: All independent variables involved in the boundary condition
 - `eq`: The boundary condition equation
 - `order`: The order of the derivative in the boundary condition
+
+# Arguments
+- `u`: The dependent-variable expression at the boundary.
+- `t`: The time variable, or `nothing` for a steady-state system.
+- `x`: The independent variable whose upper endpoint is represented.
+- `order`: The derivative order associated with the boundary condition.
+- `eq`: The symbolic boundary equation.
+- `v::VariableMap`: The variable map used to reconstruct dependent variables.
+
+# Returns
+- `UpperBoundary`: A normalized boundary representation.
+
+# Examples
+```julia
+boundary = UpperBoundary(u(t, 1), t, x, 0, u(t, 1) ~ 0, v)
+boundary.x == x
+```
 """
 struct UpperBoundary <: AbstractTruncatingBoundary
     u::Any
@@ -101,6 +142,10 @@ end
 
 Represents a boundary condition at an interface between two regions or subdomains.
 
+Use the ordinary five-field constructor after the two sides have been
+classified. The type parameters record whether each side is at its upper
+endpoint; they are `Val` types so dispatch can use the orientation.
+
 # Type Parameters
 - `IsUpper_u`: `Val{true}` if the first variable is at the upper boundary, `Val{false}` otherwise
 - `IsUpper_u2`: `Val{true}` if the second variable is at the upper boundary, `Val{false}` otherwise
@@ -116,6 +161,20 @@ Represents a boundary condition at an interface between two regions or subdomain
 It is assumed that the variables in an interface boundary condition have the same argument
 signature, differing in only one variable which defines the interface. This assumption is
 not validated but will cause errors if violated.
+
+# Arguments
+- `u`, `u2`: Dependent-variable expressions on the two sides.
+- `x`, `x2`: The interface coordinates on the two sides.
+- `eq`: The symbolic interface equation.
+
+# Returns
+- `InterfaceBoundary`: An orientation-aware interface condition.
+
+# Examples
+```julia
+boundary = InterfaceBoundary{Val(true), Val(false)}(u, u2, x, x2, u ~ u2)
+isinterface(boundary) == Val(true)
+```
 """
 struct InterfaceBoundary{IsUpper_u, IsUpper_u2} <: AbstractInterfaceBoundary
     u::Any
@@ -134,6 +193,10 @@ Higher-order interface boundary conditions involve derivatives and are handled d
 from simple interface conditions. These are typically flux conditions or derivative matching
 conditions at interfaces.
 
+Construct instances through `HigherOrderInterfaceBoundary(u, u2, x, x2, t,
+order, eq, v)` so the dependent and independent variable fields are normalized
+from `eq`.
+
 # Fields
 - `u`: The first dependent variable at the interface
 - `u2`: The second dependent variable at the interface
@@ -143,6 +206,17 @@ conditions at interfaces.
 - `indvars`: All independent variables involved in the boundary condition
 - `eq`: The interface boundary condition equation
 - `order`: The maximum order of derivatives in the boundary condition
+
+# Arguments
+- `u`, `u2`: Dependent-variable expressions on the two sides.
+- `x`, `x2`: The interface coordinates on the two sides.
+- `t`: The time variable, or `nothing` for a steady-state system.
+- `order`: The maximum derivative order represented by `eq`.
+- `eq`: The symbolic interface equation.
+- `v::VariableMap`: The variable map used to reconstruct dependent variables.
+
+# Returns
+- `HigherOrderInterfaceBoundary`: A normalized higher-order interface.
 """
 struct HigherOrderInterfaceBoundary <: AbstractInterfaceBoundary
     u::Any
@@ -184,6 +258,17 @@ end
 
 Return the dependent variable and independent boundary variable represented by
 boundary object `b`.
+
+# Arguments
+- `b::AbstractBoundary`: A lower, upper, or interface boundary.
+
+# Returns
+- `Tuple`: `(b.u, b.x)`.
+
+# Examples
+```julia
+u_at_boundary, x = getvars(boundary)
+```
 """
 getvars(b::AbstractBoundary) = (b.u, b.x)
 
@@ -192,6 +277,12 @@ getvars(b::AbstractBoundary) = (b.u, b.x)
 
 Return `true` when interface boundaries `b1` and `b2` form matching periodic
 boundary conditions.
+
+# Arguments
+- `b1`, `b2`: Interface boundaries to compare.
+
+# Returns
+- `Bool`: Whether the variable operations and interface coordinates are paired.
 """
 function isperiodic(
         b1::InterfaceBoundary{b1u, b1u2},
@@ -207,6 +298,12 @@ end
     isinterface(b)
 
 Return `Val(true)` when `b` is an `InterfaceBoundary`, otherwise `Val(false)`.
+
+# Arguments
+- `b`: A boundary representation.
+
+# Returns
+- `Val{true}` for `InterfaceBoundary` and `Val{false}` otherwise.
 """
 @inline function isinterface(b)
     if b isa InterfaceBoundary
@@ -220,6 +317,12 @@ end
     filter_interfaces(bs)
 
 Return the interface boundaries contained in the collection `bs`.
+
+# Arguments
+- `bs`: An iterable of boundary representations.
+
+# Returns
+- A vector containing only `InterfaceBoundary` values.
 """
 filter_interfaces(bs) = filter(b -> b isa InterfaceBoundary, bs)
 
@@ -228,6 +331,13 @@ filter_interfaces(bs) = filter(b -> b isa InterfaceBoundary, bs)
 
 Return booleans indicating whether interface boundaries in `bs` include lower
 and upper boundaries for independent variable `x`.
+
+# Arguments
+- `bs`: An iterable of boundary representations.
+- `x`: The independent variable to inspect.
+
+# Returns
+- `Tuple{Bool, Bool}`: `(has_lower, has_upper)`.
 """
 function haslowerupper(bs, x)
     haslower = false
@@ -249,6 +359,13 @@ end
 
 Return `true` when a nested boundary map contains at least one
 `InterfaceBoundary`.
+
+# Arguments
+- `bmps`: A nested boundary map indexed by dependent variable and independent
+  variable.
+
+# Returns
+- `Bool`: Whether at least one interface boundary is present.
 """
 function has_interfaces(bmps)
     return any(b -> b isa InterfaceBoundary, reduce(vcat, reduce(vcat, collect.(values.(collect(values(bmps)))))))
@@ -260,6 +377,12 @@ end
 
 Return `true` when boundary object `b` corresponds to the upper side of a
 domain or interface.
+
+# Arguments
+- `b`: A boundary representation.
+
+# Returns
+- `Bool`: Whether `b` is oriented to the upper side.
 """
 isupper(::LowerBoundary) = false
 isupper(::UpperBoundary) = true
@@ -272,6 +395,18 @@ isupper(::HigherOrderInterfaceBoundary) = true
     flatten_vardict(bmps)
 
 Flatten a nested boundary map into a vector of boundary objects.
+
+# Arguments
+- `bmps`: A nested boundary map indexed by dependent variable and independent
+  variable.
+
+# Returns
+- `Vector`: All boundary objects in the map, preserving map traversal order.
+
+# Examples
+```julia
+boundaries = flatten_vardict(boundarymap)
+```
 """
 flatten_vardict(bmps) = reduce(vcat, reduce(vcat, collect.(values.(collect(values(bmps))))))
 

--- a/src/periodic_map.jl
+++ b/src/periodic_map.jl
@@ -10,11 +10,27 @@ A structure that tracks periodic boundary conditions for variables in a PDE syst
 - `map`: A nested dictionary structure mapping dependent variable operations to their
   independent variables and whether each boundary is periodic
 
+# Arguments
+- `hasperiodic`: A `Val` type parameter indicating whether the map contains a
+  periodic pair.
+- `map`: A nested dictionary from dependent-variable operations to independent
+  variables and `Val` periodicity markers.
+
 # Constructor
-    PeriodicMap(bmap, v::VariableMap)
+- `PeriodicMap(bmap, v::VariableMap)`: Build the map from a parsed boundary map
+  and variable map.
 
 Constructs a `PeriodicMap` from a boundary map and variable map, automatically detecting
 which boundaries have periodic conditions.
+
+# Returns
+- `PeriodicMap{Val{true}}` or `PeriodicMap{Val{false}}`, depending on the map.
+
+# Examples
+```julia
+periodic = PeriodicMap(boundarymap, v)
+periodic.map
+```
 """
 struct PeriodicMap{hasperiodic}
     map::Any

--- a/src/symbolic_utils.jl
+++ b/src/symbolic_utils.jl
@@ -11,6 +11,18 @@ This implementation manually traverses the expression tree and:
 - DOES substitute inside the arguments of derivative calls like `Dx(u(t,x))`
 
 This allows expressions like `Dx(u(t, boundary_value))` to work correctly.
+
+# Arguments
+- `expr`: The symbolic expression to transform.
+- `dict`: An iterable of substitution pairs.
+
+# Returns
+- A symbolic expression with the requested substitutions applied.
+
+# Examples
+```julia
+pde_substitute(u(t, x), Dict(x => 0))
+```
 """
 @inline function pde_substitute(expr, dict)
     return _pde_sub(safe_unwrap(expr), Dict(safe_unwrap(k) => safe_unwrap(v) for (k, v) in pairs(dict)))
@@ -109,6 +121,11 @@ Returns a set of all differential orders present in the equation with respect to
 
 # Returns
 A set of integers representing all differential orders found in the equation (excluding zero).
+
+# Examples
+```julia
+differential_order(Dx(Dx(u)) ~ 0, x) == Set([2])
+```
 """
 function differential_order(eq, x)
     orders = Set{Int}()
@@ -170,6 +187,11 @@ Finds the first `Differential` operator or dependent variable matching `depvar_o
 
 # Returns
 The first matching derivative or dependent variable found, or `nothing` if none exists.
+
+# Examples
+```julia
+find_derivative(Dx(u) + 1, operation(u)) == Dx(u)
+```
 """
 function find_derivative(term, depvar_op)
     if iscall(term)
@@ -196,6 +218,15 @@ Applies substitution rules to all equations and boundary conditions in place.
 - `eqs`: Vector of equations to modify
 - `bcs`: Vector of boundary conditions to modify
 - `rules`: Substitution rules to apply
+
+# Returns
+- `eqs`: The mutated equation vector.
+
+# Examples
+```julia
+eqs = [u ~ x]
+subs_alleqs!(eqs, [x => 1])
+```
 """
 function subs_alleqs!(eqs, bcs, rules)
     subs_alleqs!(eqs, rules)
@@ -217,6 +248,11 @@ Finds all dependent variables matching the given operations in an expression.
 
 # Returns
 A set of all dependent variables found in the expression that match the given operations.
+
+# Examples
+```julia
+get_depvars(Dx(u) ~ u, [operation(u)])
+```
 """
 function get_depvars(eq, depvar_ops)
     depvars = Set()
@@ -284,6 +320,13 @@ end
 
 Return all dependent variables with operations in `depvar_ops` that appear in
 the equations or boundary conditions.
+
+# Arguments
+- `pdeeqs` or `pdesys::PDESystem`: Equations, or a PDE system containing them.
+- `depvar_ops`: Operations identifying dependent variables.
+
+# Returns
+- A vector of matching dependent-variable expressions.
 """
 @inline function get_all_depvars(pdeeqs, depvar_ops)
     return collect(
@@ -308,6 +351,19 @@ get_ops(depvars) = map(u -> operation(safe_unwrap(u)), depvars)
 
 Split an equation or boundary condition into symbolic terms used by PDE
 discretization rules.
+
+# Arguments
+- `eq`: An `Equation` or initial-condition `Pair`.
+- `x̄`: Optional spatial-variable collection used by the derivative-aware
+  method.
+
+# Returns
+- A vector of symbolic terms extracted from both sides of `eq`.
+
+# Examples
+```julia
+split_terms(u + Dx(u) ~ 0)
+```
 """
 function split_terms(eq::Equation)
     lhs = _split_terms(eq.lhs)
@@ -424,6 +480,18 @@ end
     split_additive_terms(eq)
 
 Return the left- and right-hand additive terms of equation `eq`.
+
+# Arguments
+- `eq`: A symbolic equation with `lhs` and `rhs` fields.
+
+# Returns
+- A vector containing additive terms from the left-hand side followed by
+  additive terms from the right-hand side.
+
+# Examples
+```julia
+split_additive_terms(u + x ~ 2u) == [u, x, 2u]
+```
 """
 function split_additive_terms(eq)
     # Calling the methods from symbolicutils matches the expressions
@@ -453,6 +521,13 @@ end
     subsmatch(expr, rule)
 
 Return `true` when `rule.first` appears anywhere in expression `expr`.
+
+# Arguments
+- `expr`: An equation or symbolic expression to search.
+- `rule`: A pair whose first element is the expression to match.
+
+# Returns
+- `Bool`: Whether the expression occurs in `expr`.
 """
 subsmatch(eq::Equation, rule) = subsmatch(eq.lhs, rule) | subsmatch(eq.rhs, rule)
 
@@ -473,6 +548,18 @@ end
 
 Convert a Term to a variable `Term`. Note that it only takes a `Term`
 not a `Num`.
+
+# Arguments
+- `term`: The symbolic term to replace.
+- `v::VariableMap`: The variable map used to identify dependent variables.
+
+# Returns
+- A new symbolic variable with the same argument signature as the selected
+  dependent variable, or `term` if it is not a call expression.
+
+# Examples
+```julia
+ex2term(Dx(u), v)
 ```
 """
 function ex2term(term, v)
@@ -497,6 +584,17 @@ safe_unwrap(x) = x isa Num ? unwrap(x) : x
     recursive_unwrap(ex)
 
 Recursively unwrap `Num` values inside a symbolic expression.
+
+# Arguments
+- `ex`: A symbolic expression, possibly containing nested `Num` wrappers.
+
+# Returns
+- The expression with wrappers removed recursively.
+
+# Examples
+```julia
+recursive_unwrap(u(x))
+```
 """
 function recursive_unwrap(ex)
     if !iscall(ex)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,18 @@
 """
-A function that creates a tuple of CartesianIndices of unit length and `N` dimensions, one pointing along each dimension.
+    unitindices(N::Int)
+
+Create one unit `CartesianIndex` for each of the `N` dimensions.
+
+# Arguments
+- `N::Int`: The number of dimensions.
+
+# Returns
+- A vector of `CartesianIndex` values, or `CartesianIndex()` when `N == 0`.
+
+# Examples
+```julia
+unitindices(2) == [CartesianIndex(1, 0), CartesianIndex(0, 1)]
+```
 """
 function unitindices(N::Int) #create unit CartesianIndex for each dimension
     null = zeros(Int, N)
@@ -16,7 +29,15 @@ end
 
 """
     unitindex(N, j)
-Get a unit `CartesianIndex` in dimension `j` of length `N`.
+
+Create a unit `CartesianIndex` in dimension `j` of an `N`-dimensional index.
+
+# Arguments
+- `N`: The number of dimensions.
+- `j`: The dimension containing the unit entry.
+
+# Returns
+- `CartesianIndex`: An index with one in dimension `j` and zero elsewhere.
 """
 unitindex(N, j) = CartesianIndex(ntuple(i -> i == j, N))
 
@@ -30,6 +51,18 @@ remove(v::AbstractVector, a::Number) = filter(x -> !isequal(x, a), v)
 
 Return derivative orders with respect to independent variable `x` that appear
 in the PDE equations or boundary conditions `pdeeqs`.
+
+# Arguments
+- `x`: The independent variable to inspect.
+- `pdeeqs`: An iterable of `Equation` or `Pair` values.
+
+# Returns
+- A descending vector of unique derivative orders.
+
+# Examples
+```julia
+d_orders(x, [Dx(Dx(u)) ~ 0]) == [2]
+```
 """
 function d_orders(x, pdeeqs)
     # Handle both Equation (has lhs, rhs) and Pair (has first, second) types

--- a/src/variable_map.jl
+++ b/src/variable_map.jl
@@ -3,6 +3,10 @@
 
 A container that maps dependent and independent variables from a `PDESystem` along with their properties.
 
+`VariableMap` is created during `SciMLBase.symbolic_discretize` and is passed to
+discretizer hooks. `VariableMap(pdesys)` is useful when a package needs to
+inspect the symbolic variables without selecting a discretization.
+
 # Fields
 - `ū`: Collection of all dependent variables (filtered to exclude boundary values)
 - `x̄`: Collection of spatial independent variables (excludes time)
@@ -14,6 +18,20 @@ A container that maps dependent and independent variables from a `PDESystem` alo
 - `x2i`: Dictionary mapping independent variables to their dimension indices
 - `i2x`: Dictionary mapping dimension indices to independent variables
 - `replaced_vars`: Dictionary of variable substitutions/replacements
+
+# Constructors
+- `VariableMap(pdesys)`: Build a map without a discretization.
+- `VariableMap(pdesys, disc; replaced_vars = Dict())`: Build a map for `disc`.
+
+# Returns
+- `VariableMap`: The normalized variable and domain information used by PDEBase.
+
+# Examples
+```julia
+v = VariableMap(pdesys)
+depvars(v)
+indvars(v)
+```
 """
 struct VariableMap
     ū::Any

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,0 +1,126 @@
+using PDEBase
+using SciMLBase
+using ModelingToolkit
+using Test
+
+struct PlainDiscretization <: SciMLBase.AbstractDiscretization end
+struct TestSpace <: PDEBase.AbstractDiscreteSpace end
+struct TestMapping <: PDEBase.AbstractVarEqMapping end
+struct TestDerivativeData <: PDEBase.AbstractDifferentialDiscretizer end
+struct TestState <: PDEBase.AbstractDiscretizationState
+    equations::Vector{Any}
+end
+struct TestMetadata <: SciMLBase.AbstractDiscretizationMetadata{false}
+    metadata::Base.RefValue{Any}
+end
+
+@testset "Default discretization interface" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    eq = Dt(u(t, x)) ~ Dx(Dx(u(t, x)))
+    pdesys = PDESystem(
+        [eq],
+        [u(0, x) ~ 0, u(t, 0) ~ 0, u(t, 1) ~ 0],
+        [t ∈ (0, 1), x ∈ (0, 1)],
+        [t, x],
+        [u(t, x)];
+        name = :pdebase_interface_test
+    )
+    v = VariableMap(pdesys)
+    plain = PlainDiscretization()
+    space = TestSpace()
+    mapping = TestMapping()
+    derivative_data = TestDerivativeData()
+    state = TestState(Any[])
+    metadata = TestMetadata(Ref{Any}(nothing))
+
+    @test PDEBase.interface_errors(pdesys, v, plain) === nothing
+    @test PDEBase.check_boundarymap(Dict(), v, plain) === nothing
+    @test PDEBase.should_transform(pdesys, plain, Dict()) === false
+    @test PDEBase.transform_pde_system!(v, Dict(), pdesys, plain) === nothing
+    @test isempty(PDEBase.construct_disc_state(plain))
+    @test PDEBase.construct_discrete_space(v, plain) === nothing
+    @test PDEBase.construct_var_equation_mapping([], Dict(), space, plain) === nothing
+    @test PDEBase.construct_differential_discretizer(pdesys, space, plain, Dict()) === nothing
+    @test PDEBase.discretize_equation!(
+        state, eq, mapping, nothing, Dict(), Any[], space, derivative_data, Dict(), plain
+    ) === nothing
+    @test PDEBase.generate_ic_defaults([], space, plain) === nothing
+    @test PDEBase.generate_metadata(space, plain, pdesys, Dict(), nothing, []) === nothing
+    @test PDEBase.generate_system(state, space, [], nothing, metadata, plain; checks = false) === nothing
+    @test PDEBase.get_time(plain) === nothing
+    @test isempty(PDEBase.get_discvars(space))
+    @test PDEBase.get_eqvar(mapping, eq) === nothing
+    @test PDEBase.add_metadata!(metadata, :symbolic_system) === :symbolic_system
+    @test metadata.metadata[] === :symbolic_system
+end
+
+struct MockDiscretization <: PDEBase.AbstractEquationSystemDiscretization
+    time::Any
+end
+struct MockSpace <: PDEBase.AbstractDiscreteSpace
+    eqvar::Any
+end
+struct MockMapping <: PDEBase.AbstractVarEqMapping
+    eqvar::Any
+end
+struct MockDerivativeData <: PDEBase.AbstractDifferentialDiscretizer end
+struct MockState <: PDEBase.AbstractDiscretizationState
+    equations::Vector{Any}
+end
+struct MockMetadata <: SciMLBase.AbstractDiscretizationMetadata{true}
+    metadata::Base.RefValue{Any}
+end
+
+PDEBase.get_time(disc::MockDiscretization) = disc.time
+PDEBase.construct_disc_state(::MockDiscretization) = MockState(Any[])
+PDEBase.construct_discrete_space(v::VariableMap, ::MockDiscretization) = MockSpace(first(depvars(v)))
+PDEBase.construct_var_equation_mapping(_, _, space::MockSpace, ::MockDiscretization) =
+    MockMapping(space.eqvar)
+PDEBase.construct_differential_discretizer(_, _, ::MockDiscretization, _) = MockDerivativeData()
+PDEBase.get_eqvar(mapping::MockMapping, _) = mapping.eqvar
+function PDEBase.discretize_equation!(
+        state::MockState, pde::Equation, ::MockMapping, _, _, _, ::MockSpace,
+        ::MockDerivativeData, _, ::MockDiscretization
+    )
+    push!(state.equations, pde)
+    return nothing
+end
+PDEBase.generate_ic_defaults(_, ::MockSpace, ::MockDiscretization) = :u0
+PDEBase.generate_metadata(_, ::MockDiscretization, _, _, _, _) = MockMetadata(Ref{Any}(nothing))
+function PDEBase.generate_system(
+        state::MockState, space::MockSpace, u0, tspan, metadata::MockMetadata,
+        ::MockDiscretization; checks = true
+    )
+    return state, space, u0, tspan, metadata, checks
+end
+PDEBase.get_discvars(space::MockSpace) = (space.eqvar,)
+
+@testset "Generic discretization hook dispatch" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    pdesys = PDESystem(
+        [Dt(u(t, x)) ~ Dx(Dx(u(t, x)))],
+        [u(0, x) ~ 0, u(t, 0) ~ 0, u(t, 1) ~ 0],
+        [t ∈ (0, 1), x ∈ (0, 1)],
+        [t, x],
+        [u(t, x)];
+        name = :pdebase_generic_interface_test
+    )
+
+    result = SciMLBase.symbolic_discretize(pdesys, MockDiscretization(t); checks = false)
+    state, space, u0, tspan, metadata, checks = result
+
+    @test length(state.equations) == 1
+    @test space isa MockSpace
+    @test PDEBase.get_discvars(space) == (space.eqvar,)
+    @test u0 === :u0
+    @test tspan == (0, 1)
+    @test metadata isa MockMetadata
+    @test checks === false
+    @test PDEBase.get_time(MockDiscretization(t)) === t
+end


### PR DESCRIPTION
This draft should be ignored until reviewed by @ChrisRackauckas.

## What changed

- Put SciMLStyle docstrings at the definition sites for PDEBase's public types, boundary utilities, symbolic utilities, and developer extension hooks.
- Reworked the developer extension API page to specify the pipeline, input rules, hook contracts, abstract extension types, and a minimal implementation skeleton. The page warns ordinary users not to build directly on developer hooks.
- Added generic interface tests covering default hook contracts and an end-to-end concrete discretization dispatch.
- Fixed invalid developer-API cross-references so the docs build succeeds.

The current upstream `master` already contains `SciMLTesting = "2.4"` in both the root and QA test environments, uses plain `run_qa(PDEBase)`, and has no repository-specific `api_docs_kwargs` or rendered override. This PR intentionally contains no compat-only change.

## Verification

- Runic: clean for all changed Julia files.
- `typos`: clean.
- `git diff --check`: clean.
- `julia --startup-file=no --compiled-modules=no --project=. test/interface.jl`: `Default discretization interface | 17 / 17`; `Generic discretization hook dispatch | 8 / 8`.
- `GROUP=Core timeout 3600 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: all Core groups passed, including `Core/interface.jl | 25 / 25` and `Core/public_api.jl | 46 / 46`.
- `GROUP=QA timeout 3600 julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: `QA/qa.jl | 20 / 20`; `Testing PDEBase tests passed`.
- `julia --startup-file=no --project=. -e 'include("make.jl")'` from `docs/`: Documenter doctests, cross-references, document checks, and HTML rendering completed successfully. Deployment was skipped because the build was run outside CI.

The full downstream suite and non-default Julia-version matrix were not run locally.
