### PR TITLE
Drop stale MethodOfLines MOL_Interface2 IntegrationTest group

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -15,7 +15,6 @@ jobs:
           - {user: SciML, repo: MethodOfLines.jl, group: Components}
           - {user: SciML, repo: MethodOfLines.jl, group: Sol_Interface}
           - {user: SciML, repo: MethodOfLines.jl, group: MOL_Interface1}
-          - {user: SciML, repo: MethodOfLines.jl, group: MOL_Interface2}
           - {user: SciML, repo: MethodOfLines.jl, group: Diffusion}
           - {user: SciML, repo: MethodOfLines.jl, group: Nonlinear_Diffusion}
           - {user: SciML, repo: MethodOfLines.jl, group: 2D_Diffusion}


### PR DESCRIPTION
Workflow-only. MethodOfLines `test/test_groups.toml` declares `MOL_Interface1` and does not declare `MOL_Interface2`. SciMLTesting folder-discovery mode errors on an unknown `GROUP`.

## What changed

Remove the `MOL_Interface2` matrix cell. `MOL_Interface1` and the other current MOL groups stay.

## Verification

Parsed post-change `.github/workflows/Downstream.yml` against MethodOfLines `test/test_groups.toml` (SHA `806d7a85596d`). Every remaining `group` is a declared key. `MOL_Interface2` is gone.

Did not wait for GitHub Actions. No GPU / self-hosted jobs in this workflow.

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)