### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/parse_boundaries.jl
+++ b/src/parse_boundaries.jl
@@ -417,15 +417,15 @@ function _boundary_rules(v, orders, u, x, val)
 
     spacerules = [
         (Differential(x)^d)(operation(u)(args...)) => [
-                operation(u)(args...), x, d,
-            ] for d in reverse(orders[x])
+            operation(u)(args...), x, d,
+        ] for d in reverse(orders[x])
     ]
 
     if v.time !== nothing && x !== v.time
         timerules = [
             Differential(v.time)(operation(u)(args...)) => [
-                    operation(u)(args...), x, d,
-                ] for d in reverse(orders[v.time])
+                operation(u)(args...), x, d,
+            ] for d in reverse(orders[v.time])
         ]
         return vcat(spacerules, timerules, varrule)
     else
@@ -442,26 +442,26 @@ function generate_boundary_matching_rules(v, orders)
     lower = Dict(
         [
             operation(u) => Dict(
-                    [
-                        x => _boundary_rules(
-                            v, orders, u, x, lowerboundary(x)
-                        )
+                [
+                    x => _boundary_rules(
+                        v, orders, u, x, lowerboundary(x)
+                    )
                         for x in all_ivs(u, v)
-                    ]
-                ) for u in v.ū
+                ]
+            ) for u in v.ū
         ]
     )
 
     upper = Dict(
         [
             operation(u) => Dict(
-                    [
-                        x => _boundary_rules(
-                            v, orders, u, x, upperboundary(x)
-                        )
+                [
+                    x => _boundary_rules(
+                        v, orders, u, x, upperboundary(x)
+                    )
                         for x in all_ivs(u, v)
-                    ]
-                ) for u in v.ū
+                ]
+            ) for u in v.ū
         ]
     )
 


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `a339c85082e5`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/parse_boundaries.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  2m02.8s
Testing PDEBase tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Core/alloc_tests.jl | 12 pass, 12 total
Core/array_variables.jl | 11 pass, 11 total
Core/discrete_initialization.jl | 18 pass, 18 total
Core/docs_project.jl | 1 pass, 1 total
Core/interface.jl | 25 pass, 25 total
Core/public_api.jl | 46 pass, 46 total
Testing PDEBase tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
