### PR TITLE
Set the time span on the system symbolic_discretize returns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PDEBase"
 uuid = "a7812802-0625-4b9e-961c-d332478797e5"
-version = "0.1.34"
+version = "0.1.35"
 authors = ["xtalax <alex.lemony@gmail.com>"]
 
 [deps]
@@ -20,7 +20,7 @@ AllocCheck = "0.2"
 BenchmarkTools = "1"
 DomainSets = "0.7, 0.8"
 IntervalSets = "0.7"
-ModelingToolkitBase = "1.58"
+ModelingToolkitBase = "1.69"
 ModelingToolkit = "11.26.7"
 PrecompileTools = "1.2.1"
 SciMLBase = "3.1"

--- a/src/discretization_state.jl
+++ b/src/discretization_state.jl
@@ -137,6 +137,7 @@ function generate_system(
                 initial_conditions = sys_defaults,
                 initialization_eqs = init_eqs,
                 guesses = guesses,
+                tspan = tspan,
                 name = name,
                 metadata = [ProblemTypeCtx => metadata], checks = checks
             )

--- a/src/interface_defaults.jl
+++ b/src/interface_defaults.jl
@@ -301,7 +301,9 @@ generate_metadata(s, discretization, pdesys, boundarymap, complexmap, u0 = []) =
 Build the final symbolic system from the accumulated discretization results.
 
 The returned value is passed back through `SciMLBase.symbolic_discretize`; in
-the usual time-dependent case it is a tuple `(system, tspan)`. Use `checks` when
+the usual time-dependent case it is a tuple `(system, tspan)`. Set `tspan` on the
+system as well, so that a caller who keeps only the system can still build a
+time-dependent problem without supplying a time span. Use `checks` when
 constructing the symbolic system and forward it to the constructor rather than
 silently changing validation behavior.
 

--- a/test/system_tspan.jl
+++ b/test/system_tspan.jl
@@ -1,0 +1,55 @@
+using PDEBase
+using ModelingToolkit
+using ModelingToolkitBase: get_tspan
+using SciMLBase
+using Symbolics
+using Test
+
+struct TspanDiscretization <: PDEBase.AbstractEquationSystemDiscretization
+    time::Any
+end
+struct TspanSpace <: PDEBase.AbstractDiscreteSpace
+    discvars::Any
+end
+struct TspanMetadata <: SciMLBase.AbstractDiscretizationMetadata{true}
+    pdesys::Any
+end
+
+PDEBase.get_time(disc::TspanDiscretization) = disc.time
+PDEBase.get_discvars(s::TspanSpace) = s.discvars
+
+@testset "Discretized system carries the time span" begin
+    @parameters t x
+    @variables u(..)
+    Dt = Differential(t)
+    Dx = Differential(x)
+    pdesys = PDESystem(
+        [Dt(u(t, x)) ~ Dx(Dx(u(t, x)))],
+        [u(0, x) ~ 0, u(t, 0) ~ 0, u(t, 1) ~ 0],
+        [t ∈ (0, 1), x ∈ (0, 1)],
+        [t, x],
+        [u(t, x)];
+        name = :pdebase_tspan_test
+    )
+
+    @variables w1(t) w2(t)
+    space = TspanSpace(Dict(:u => [w1, w2]))
+    state = PDEBase.EquationState([Dt(w1) ~ -w1, Dt(w2) ~ w1 - w2], Equation[])
+
+    sys, tspan = PDEBase.generate_system(
+        state, space, [], (0.0, 2.5), TspanMetadata(pdesys), TspanDiscretization(t)
+    )
+    @test tspan == (0.0, 2.5)
+    @test get_tspan(sys) == (0.0, 2.5)
+    # the span has to survive compilation, which is where a problem is built from
+    @test ODEProblem(mtkcompile(sys), [w1 => 1.0, w2 => 0.0]).tspan == (0.0, 2.5)
+
+    @variables z1 z2
+    nlstate = PDEBase.EquationState([z1 ~ 1.0, z2 ~ z1 + 1.0], Equation[])
+    nlspace = TspanSpace(Dict(:u => [z1, z2]))
+    nlsys, nltspan = PDEBase.generate_system(
+        nlstate, nlspace, [], nothing, TspanMetadata(pdesys), TspanDiscretization(nothing)
+    )
+    @test nltspan === nothing
+    @test get_tspan(nlsys) === nothing
+end


### PR DESCRIPTION
## What changed and why

`generate_system` already receives the `tspan` it returns alongside the system. It now also passes it to the `System` constructor, so the discretized system carries its own time span (the `tspan` field added to `System` in ModelingToolkitBase 1.69.0, https://github.com/SciML/ModelingToolkit.jl/pull/5085). A caller that keeps only the system can then write `ODEProblem(sys, u0)` and get the PDE's own time interval, rather than threading the tuple's second element out of band.

Motivation: https://github.com/SciML/ModelOrderReduction.jl/issues/29.

**The return type is unchanged.** `symbolic_discretize` still returns `(system, tspan)` and `generate_system` still returns that tuple; downstream code that unpacks it, including ModelOrderReduction's test suite, is unaffected. This is purely additive.

The steady-state branch (`t === nothing`) builds a `NonlinearSystem` and is untouched, so a time-independent `PDESystem` does not acquire a bogus time span. That is asserted in the new test.

`[compat]` bump: `ModelingToolkitBase = "1.69"` (was `"1.58"`). 1.69.0 is registered and merged (https://github.com/JuliaRegistries/General/pull/167382), so this resolves today. PDEBase depends on ModelingToolkitBase directly, so declaring the floor here is sufficient — it does not depend on the ModelingToolkit 11.42.0 release. Version bumped 0.1.34 → 0.1.35.

## Why here and not in MethodOfLines

The task this came from was framed as a MethodOfLines change, but MethodOfLines constructs no `System` of its own — it consumes `PDEBase.symbolic_discretize`, and `PDEBase.generate_system` is the single place the discretized `System` is built. Setting the span from MethodOfLines would mean either duplicating this function or mutating a constructed `System` through a non-public setter (`@set sys.tspan`), since ModelingToolkitBase exposes `tspan` only as a constructor keyword. Doing it at the construction site is one line and fixes every PDEBase-based discretizer, not just `MOLFiniteDifference`.

The companion MethodOfLines PR is https://github.com/SciML/MethodOfLines.jl/pull/685 — it bumps the PDEBase floor and adds the end-to-end test through a real `MOLFiniteDifference` discretization.

## Verification

Julia 1.12.7, `ModelingToolkitBase v1.69.0` and `ModelingToolkit v11.41.0` from the registry.

### The new test fails without the fix

With the one added line (`tspan = tspan,`) deleted from `generate_system` and everything else identical:

```
$ GROUP=Core julia +1 --project=. -e 'using Pkg; Pkg.test()'
Discretized system carries the time span: Test Failed at .../PDEBase/test/system_tspan.jl:43
  Expression: get_tspan(sys) == (0.0, 2.5)
   Evaluated: nothing == (0.0, 2.5)

Discretized system carries the time span: Error During Test at .../PDEBase/test/system_tspan.jl:45
  Test threw exception
  Expression: (ODEProblem(mtkcompile(sys), [w1 => 1.0, w2 => 0.0])).tspan == (0.0, 2.5)
  No timespan was given, and the system `pdebase_tspan_test` does not have one. Either pass the
  timespan to the problem constructor, or give the system a default timespan by constructing it
  with the `tspan` keyword argument, e.g. `System(eqs, t; tspan = (0.0, 1.0), name = :pdebase_tspan_test)`.
   [1] default_tspan
     @ ModelingToolkitBase/src/problems/compatibility.jl:290 [inlined]
   [2] SciMLBase.ODEProblem(sys::ModelingToolkitBase.System, op::Vector{Pair{Symbolics.Num, Float64}})

Test Summary:                              | Pass  Fail  Error  Total     Time
Core/system_tspan.jl                       |    3     1      1      5  1m07.9s
ERROR: Package PDEBase errored during testing
```

The two assertions that pass either way are the `nothing`-tspan (steady-state) ones, which is the point of including them.

### And passes with it

```
$ GROUP=Core julia +1 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:       | Pass  Total   Time
Core/alloc_tests.jl |   12     12  26.4s
Test Summary:           | Pass  Total  Time
Core/array_variables.jl |   11     11  7.2s
Test Summary:                   | Pass  Total   Time
Core/discrete_initialization.jl |   18     18  10.7s
Test Summary:        | Pass  Total  Time
Core/docs_project.jl |    1      1  0.0s
Test Summary:     | Pass  Total   Time
Core/interface.jl |   25     25  13.5s
Test Summary:      | Pass  Total  Time
Core/public_api.jl |   46     46  0.1s
Test Summary:        | Pass  Total     Time
Core/system_tspan.jl |    5      5  1m31.3s
     Testing PDEBase tests passed
```

```
$ GROUP=QA julia +1 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m39.9s
     Testing PDEBase tests passed
```

```
$ julia +1 --project=@runic -m Runic --check .
(no output, exit 0)

$ typos .
(no output, exit 0)
```

I also checked separately that the span survives the rest of the pipeline, since that is what makes the field useful here — a hand-built `System(...; tspan = (0.0, 3.0))` keeps it through `complete`, through `mtkcompile`, and into `ODEProblem(simp, nothing).tspan == (0.0, 3.0)`.

## Not verified

- Downstream packages other than MethodOfLines. `Pkg.test()` here does not exercise them, and the compat floor bump means downstreams need a release before they see this.
- The docs build (`docs/make.jl`) — the only docs change is one paragraph inside an existing `generate_system` docstring, no new entries.

## What a reviewer should push back on

- Whether the `ModelingToolkitBase` floor jumping 1.58 → 1.69 is acceptable, or whether the field should be set behind a `has_tspan`-style feature check to keep the floor low. I chose the hard floor because a soft check would silently give the old, tspan-less behaviour on an older ModelingToolkitBase and make the MethodOfLines test flaky depending on resolution.
- Whether the `generate_system` docstring change reads as an instruction to third-party discretizers (it is meant to: a discretizer implementing this hook should set the span too).

Ignore this PR until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5RuLDtEazwTKPkNbPeZVu
